### PR TITLE
v14 Update w/v13 Backwards Compatibility

### DIFF
--- a/lang/en/notification.json
+++ b/lang/en/notification.json
@@ -7,6 +7,8 @@
       "LastingStateReduced": "{name} returns to lasting intensity {intensity}.",
       "Item": {
         "DropDeedsOnly": "Only Deeds can be dropped here.",
+        "Added": "Added {item} to {target}.",
+        "EffectMerged": "{effect} merged into the existing effect on {target} (intensity {intensity}).",
         "DropEffectsStatesOnly": "Only Effects or States can be dropped here.",
         "AlreadyAdded": "{name} has already been added.",
         "DropArmorOnly": "Only Effects and States can be applied to Armor.",
@@ -34,6 +36,7 @@
       },
       "Combat": {
         "NoTargets": "No targets selected. Aborting.",
+        "RecordedTargetsGone": "The targets recorded on this card are no longer on the scene.",
         "NoTargetsAbort": "No targets selected! Roll aborted, showing basic Accuracy for reference.",
         "NoTargetsDefault": "No targets selected! Rolling against default CD 10.",
         "NotEnoughFocus": "Insufficient Focus to use {name}. (Required {cost}, has {current})",

--- a/lang/en/terms.json
+++ b/lang/en/terms.json
@@ -28,7 +28,7 @@
         "Reaction": "Reaction"
       },
       "Attribute": {
-        "Mighty": "Mighty",
+        "Mighty": "Might",
         "Agility": "Agility",
         "Intellect": "Intellect",
         "Spirit": "Spirit",

--- a/lang/pt-BR/notification.json
+++ b/lang/pt-BR/notification.json
@@ -7,6 +7,8 @@
       "LastingStateReduced": "{name} retorna à intensidade duradoura de {intensity}.",
       "Item": {
         "DropDeedsOnly": "Apenas Habilidades podem ser soltas aqui.",
+        "Added": "{item} adicionado a {target}.",
+        "EffectMerged": "{effect} foi mesclado ao efeito existente em {target} (intensidade {intensity}).",
         "DropEffectsStatesOnly": "Apenas Efeitos ou Estados podem ser soltos aqui.",
         "AlreadyAdded": "{name} já foi adicionado.",
         "DropArmorOnly": "Apenas Efeitos e Estados podem ser aplicados em Armaduras.",
@@ -34,6 +36,7 @@
       },
       "Combat": {
         "NoTargets": "Nenhum alvo selecionado. Abortando.",
+        "RecordedTargetsGone": "Os alvos registrados neste cartão não estão mais na cena.",
         "NoTargetsAbort": "Nenhum alvo selecionado! Rolagem abortada, exibindo Acurácia básica para referência.",
         "NoTargetsDefault": "Nenhum alvo selecionado! Rolando contra CD 10 padrão.",
         "NotEnoughFocus": "Foco insuficiente para usar {name}. (Necessário {cost}, possui {current})",

--- a/module/data/actor-haven.mjs
+++ b/module/data/actor-haven.mjs
@@ -617,7 +617,6 @@ export class TrespasserHavenData extends foundry.abstract.TypeDataModel {
    * @param {Object} [delta] - The update delta, if called from a hook.
    */
   async syncStrongholdBenefit(stronghold, delta = {}) {
-    console.warn("here");
     const actor = this.parent;
     if (stronghold.type !== "stronghold") return;
     

--- a/module/dialogs/trespasser-config-v2.mjs
+++ b/module/dialogs/trespasser-config-v2.mjs
@@ -141,7 +141,7 @@ export class TrespasserConfigV2 extends foundry.applications.api.HandlebarsAppli
    * @param {Event} event 
    */
   static async _onSubmit(event) {
-    const formData = new FormDataExtended(this.element).object;
+    const formData = new foundry.applications.ux.FormDataExtended(this.element).object;
     
     // Handle standard settings
     for ( let [key, val] of Object.entries(formData) ) {

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -1,5 +1,6 @@
 import { TrespasserEffectsHelper } from "../helpers/effects-helper.mjs";
 import { TrespasserCombat } from './combat.mjs';
+import { messageVisibility } from "../helpers/compat.mjs";
 
 /**
  * Custom Actor document class for Trespasser TTRPG.
@@ -741,8 +742,8 @@ export class TrespasserActor extends Actor {
         const roll = new foundry.dice.Roll(expr);
         await roll.evaluate();
         const hideCreatureRolls = game.settings.get("trespasser", "hideCreatureDamageRolls");
-        const rollMode = (this.type === "creature" && hideCreatureRolls) ? "gmroll" : "roll";
-        await roll.toMessage({ speaker: ChatMessage.getSpeaker({ actor: this }), flavor: flavorHtml }, { rollMode });
+        const visibility = messageVisibility((this.type === "creature" && hideCreatureRolls) ? "gm" : "public");
+        await roll.toMessage({ speaker: ChatMessage.getSpeaker({ actor: this }), flavor: flavorHtml }, visibility);
       } catch (e) {
         console.error(e);
         await ChatMessage.create({ speaker: ChatMessage.getSpeaker({ actor: this }), content: flavorHtml });

--- a/module/documents/combat.mjs
+++ b/module/documents/combat.mjs
@@ -554,7 +554,7 @@ export class TrespasserCombat extends Combat {
     if (!game.settings.get("trespasser", "showPerilInChat")) return;
     
     const label = game.i18n.localize(combatInfo.perilLabel);
-    const content = await renderTemplate("systems/trespasser/templates/chat/peril-card.hbs", {
+    const content = await foundry.applications.handlebars.renderTemplate("systems/trespasser/templates/chat/peril-card.hbs", {
       total: combatInfo.perilTotal,
       label: label,
       heavy: combatInfo.heavy,
@@ -563,10 +563,8 @@ export class TrespasserCombat extends Combat {
     });
 
     await ChatMessage.create({
-      user: game.user.id,
       content: content,
-      flavor: game.i18n.localize("TRESPASSER.Terms.Combat.Peril"),
-      type: CONST.CHAT_MESSAGE_TYPES.OTHER
+      flavor: game.i18n.localize("TRESPASSER.Terms.Combat.Peril")
     });
   }
 
@@ -579,8 +577,7 @@ export class TrespasserCombat extends Combat {
     
     // Post attempt to chat
     await ChatMessage.create({
-      content: `<h3 style="color:var(--trp-gold-bright)">${game.i18n.localize("TRESPASSER.Chat.Retreat.Attempt")}</h3>`,
-      type: CONST.CHAT_MESSAGE_TYPES.OTHER
+      content: `<h3 style="color:var(--trp-gold-bright)">${game.i18n.localize("TRESPASSER.Chat.Retreat.Attempt")}</h3>`
     });
 
     if (playerFacingInit) {
@@ -634,8 +631,7 @@ export class TrespasserCombat extends Combat {
 
     if (success) {
       await ChatMessage.create({
-        content: `<h2 style="color:var(--trp-green-bright)">${game.i18n.format("TRESPASSER.Chat.Retreat.PartyEscaped", { successes, total: pcs.length })}</h2>`,
-        type: CONST.CHAT_MESSAGE_TYPES.OTHER
+        content: `<h2 style="color:var(--trp-green-bright)">${game.i18n.format("TRESPASSER.Chat.Retreat.PartyEscaped", { successes, total: pcs.length })}</h2>`
       });
       
       if (game.settings.get("trespasser", "autoEndCombatOnRetreat")) {
@@ -644,8 +640,7 @@ export class TrespasserCombat extends Combat {
       }
     } else {
       await ChatMessage.create({
-        content: `<h2 style="color:var(--trp-red)">${game.i18n.format("TRESPASSER.Chat.Retreat.PartyFailed", { successes, total: pcs.length, needed })}</h2>`,
-        type: CONST.CHAT_MESSAGE_TYPES.OTHER
+        content: `<h2 style="color:var(--trp-red)">${game.i18n.format("TRESPASSER.Chat.Retreat.PartyFailed", { successes, total: pcs.length, needed })}</h2>`
       });
     }
 

--- a/module/helpers/compat.mjs
+++ b/module/helpers/compat.mjs
@@ -1,0 +1,22 @@
+/**
+ * Compatibility helpers for supporting Foundry v13 and v14 with one
+ * codebase. Delete this module (and inline the v14 paths) once v13
+ * support is dropped.
+ */
+
+/** Whether the running Foundry core is generation 14 or later. */
+export function isAtLeastV14() {
+  return game.release.generation >= 14;
+}
+
+/**
+ * Message-creation options controlling who sees a roll message.
+ * v14 replaced the rollMode option with messageMode (new string values,
+ * old option removed in v16); v13 only understands rollMode.
+ * @param {"public"|"gm"} mode
+ * @returns {object} Options for Roll#toMessage or RollTable#draw.
+ */
+export function messageVisibility(mode) {
+  if (isAtLeastV14()) return { messageMode: mode };
+  return { rollMode: mode === "gm" ? "gmroll" : "publicroll" };
+}

--- a/module/helpers/effects-helper.mjs
+++ b/module/helpers/effects-helper.mjs
@@ -911,7 +911,8 @@ export class TrespasserEffectsHelper {
       const ae = existingActiveEffects.find(ae => ae.getFlag("trespasser", "sourceItem") === item.id);
       
       const statusIconPath = item.system.statusIcon;
-      const matchingStatus = CONFIG.statusEffects.find(se => {
+      // Object.values handles both the v13 array and v14 object formats
+      const matchingStatus = Object.values(CONFIG.statusEffects).find(se => {
         const img = se.img || se.icon || se.src;
         return img === statusIconPath;
       });

--- a/module/helpers/targeting-helper.mjs
+++ b/module/helpers/targeting-helper.mjs
@@ -15,9 +15,11 @@
  *
  * placeTemplate() returns { squares, templateDoc } or null.
  * squares = array of {x, y} top-left pixel positions.
- * templateDoc = MeasuredTemplateDocument (only for aura, for persistent visual).
+ * templateDoc = RegionDocument (only for aura, for persistent visual).
  * Use getTokensInSquares() for target resolution on all AOE types.
  */
+
+import { isAtLeastV14 } from "./compat.mjs";
 
 export class TargetingHelper {
 
@@ -30,7 +32,7 @@ export class TargetingHelper {
    * @param {Actor}  actor
    * @param {Token}  token   The caster's token
    * @param {object} deed    item.system of the deed
-   * @returns {Promise<{squares: Array<{x:number,y:number}>, templateDoc: MeasuredTemplateDocument|null}|null>}
+   * @returns {Promise<{squares: Array<{x:number,y:number}>, templateDoc: RegionDocument|null}|null>}
    */
   static async placeTemplate(actor, token, deed, activeWeapons = []) {
     const type = deed.targetType;
@@ -52,9 +54,9 @@ export class TargetingHelper {
       case "aura": {
         const squares = this.#computeBurstSquares(token, size, gridPx);
         let templateDoc = null;
-        // Aura persists visually using a MeasuredTemplate
+        // Aura persists visually using a token-attached Region emanation
         if (type === "aura") {
-          templateDoc = await this.#createAuraTemplate(token, size, gridPx);
+          templateDoc = await this.#createAuraRegion(token, size);
         }
         return { squares, templateDoc };
       }
@@ -346,15 +348,28 @@ export class TargetingHelper {
   }
 
   /**
-   * Create a persistent MeasuredTemplate for an aura (visual only).
-   * Uses a circle to approximate the square shape visually on the canvas.
+   * Create a persistent aura visual. MeasuredTemplates were removed in
+   * Foundry v14, where a token-attached Region emanation covers the same
+   * squares and follows the token; v13 keeps the original circle template.
    */
-  static async #createAuraTemplate(token, sizeInSquares, gridPx) {
+  static async #createAuraRegion(token, sizeInSquares) {
     const gridDist = canvas.dimensions?.distance || canvas.scene?.grid?.distance || 5;
-    // Use a circle with radius = size + 0.5 (to visually cover the grid squares)
-    const distance = (sizeInSquares + 0.5) * gridDist;
 
-    const templateData = {
+    if (isAtLeastV14()) {
+      // Emanation range extends outward from the token's edge in grid units
+      const range = sizeInSquares * gridDist;
+      const region = await CONFIG.Region.documentClass.createTokenEmanation(token.document, range, {
+        name: game.i18n.localize("TRESPASSER.Sheet.Item.Details.TargetTypeChoices.Aura"),
+        color: "#5599ff",
+        visibility: CONST.REGION_VISIBILITY.ALWAYS,
+        flags: { trespasser: { autoPlaced: true, isAura: true } }
+      });
+      return region ?? null;
+    }
+
+    // v13: a circle with radius size + 0.5 visually covers the aura squares
+    const distance = (sizeInSquares + 0.5) * gridDist;
+    const [doc] = await canvas.scene.createEmbeddedDocuments("MeasuredTemplate", [{
       t: "circle",
       x: token.center.x,
       y: token.center.y,
@@ -362,9 +377,7 @@ export class TargetingHelper {
       direction: 0,
       fillColor: "#5599ff",
       flags: { trespasser: { autoPlaced: true, isAura: true } }
-    };
-
-    const [doc] = await canvas.scene.createEmbeddedDocuments("MeasuredTemplate", [templateData]);
+    }]);
     return doc;
   }
 

--- a/module/sheets/actor-character-sheet.mjs
+++ b/module/sheets/actor-character-sheet.mjs
@@ -94,6 +94,8 @@ export class TrespasserCharacterSheet extends api.HandlebarsApplicationMixin(she
         if (user.id === game.user.id) this.render();
       });
     }
+
+    this.#bindItemDragHandlers();
   }
 
   /** @override */
@@ -105,22 +107,87 @@ export class TrespasserCharacterSheet extends api.HandlebarsApplicationMixin(she
     return super.close(options);
   }
 
-  /** @override */
-  async _onDropItem(event, data) {
-    // Allow transfers from other actors even if the user doesn't own the target.
-    // Prevent cloning from sidebar/compendiums if the user doesn't own the target.
-    if ( !this.actor.isOwner && (data.type !== "Item" || !data.actorId) ) return false;
+  /**
+   * Make item rows draggable with standard Foundry drag data. Core's v14
+   * sheet drag-drop rework no longer binds drag handlers to system markup,
+   * so the sheet wires its own dragstart listeners.
+   */
+  #bindItemDragHandlers() {
+    for (const el of this.element.querySelectorAll('[draggable="true"]')) {
+      if (el._trespasserDragBound) continue;
+      el._trespasserDragBound = true;
+      el.addEventListener("dragstart", ev => {
+        const id = el.dataset.itemId ?? el.closest("[data-item-id]")?.dataset.itemId;
+        const item = id ? this.actor.items.get(id) : null;
+        if (!item) return;
+        ev.dataTransfer.setData("text/plain", JSON.stringify(item.toDragData()));
+      });
+    }
+  }
 
-    // Resolve the source item document
-    let sourceItem = data.uuid ? await fromUuid(data.uuid) : null;
-    if (!sourceItem && data.actorId && data.id) {
-       const sourceActor = game.actors.get(data.actorId) || canvas.tokens.get(data.actorId)?.actor;
-       sourceItem = sourceActor?.items.get(data.id);
+  /** @override */
+  async _onDrop(event) {
+    // Haven withdrawals carry a custom payload without a uuid, which core's
+    // drop pipeline cannot resolve to an Item — handle them before it runs.
+    const data = foundry.applications.ux.TextEditor.implementation.getDragEventData(event);
+    if (data?.isHavenTransfer) return this.#onDropHavenTransfer(data);
+    return super._onDrop(event);
+  }
+
+  /**
+   * Withdraw an item dragged from a Haven's inventory.
+   * @param {object} data  The haven-transfer drag payload.
+   */
+  async #onDropHavenTransfer(data) {
+    const sourceHaven = game.actors.get(data.actorId);
+    if (!sourceHaven) return false;
+
+    const entry = sourceHaven.system.inventory[data.havenIndex];
+    if (!entry) return false;
+
+    const itemData = foundry.utils.duplicate(entry.item);
+    const qtyToTransfer = data.transferAll ? entry.quantity : 1;
+
+    const success = await addItemToActor(this.actor, itemData, qtyToTransfer);
+    console.log(`Trespasser | Haven Transfer: Item added to character: ${success}`);
+
+    if (success) {
+      console.log(`Trespasser | Haven Transfer: Emitting HAVEN_WITHDRAWAL socket for index ${data.havenIndex}`);
+      // Notify through socket to update Haven (handles permissions)
+      TrespasserSocket.emit("HAVEN_WITHDRAWAL", {
+        havenUuid: sourceHaven.uuid,
+        index: data.havenIndex,
+        targetActorUuid: this.actor.uuid,
+        transferAll: !!data.transferAll
+      });
+
+      ui.notifications.info(game.i18n.format("TRESPASSER.Notification.Transfer.Complete", {
+        item: entry.item.name,
+        target: this.actor.name
+      }));
     }
 
-    // Determine if this is a cross-actor transfer
-    // We check if the item has a parent and that parent is NOT the current actor.
-    const isTransfer = sourceItem && sourceItem.parent && (sourceItem.parent !== this.actor);
+    return false;
+  }
+
+  /** @override */
+  async _onDropItem(event, dropped) {
+    // Guard against the drop being processed twice if both core's pipeline
+    // and a fallback listener route the same event here.
+    if (event._trespasserItemDropHandled) return false;
+    event._trespasserItemDropHandled = true;
+
+    // v14 passes the resolved Item document; raw drag data is normalized
+    // here as well so the handler tolerates either calling convention.
+    const sourceItem = dropped instanceof Item
+      ? dropped
+      : await Item.implementation.fromDropData(dropped ?? {});
+
+    // A drop from another actor is a transfer, which the receiving user may
+    // accept without owning this sheet; anything else (sidebar/compendium
+    // cloning) still requires ownership.
+    const isTransfer = !!sourceItem?.parent && (sourceItem.parent !== this.actor);
+    if (!this.actor.isOwner && !isTransfer) return false;
 
     if (isTransfer) {
       // Trigger the unified transfer logic
@@ -128,46 +195,29 @@ export class TrespasserCharacterSheet extends api.HandlebarsApplicationMixin(she
       return false; // Prevent duplicate handling
     }
 
-    // Special handling for Haven inventory transfers
-    if (data.isHavenTransfer) {
-      const sourceHaven = game.actors.get(data.actorId);
-      if (!sourceHaven) return false;
-      
-      const entry = sourceHaven.system.inventory[data.havenIndex];
-      if (!entry) return false;
+    // Dropping an item onto its own sheet reorders it
+    if (sourceItem && sourceItem.parent === this.actor) return this.#onSortItem(event, sourceItem);
 
-      const itemData = foundry.utils.duplicate(entry.item);
-      const qtyToTransfer = data.transferAll ? entry.quantity : 1;
-      
-      const success = await addItemToActor(this.actor, itemData, qtyToTransfer);
-      console.log(`Trespasser | _onDropItem (Haven Transfer): Item added to character: ${success}`);
+    if (!sourceItem) return super._onDropItem(event, dropped);
+    if (sourceItem.type === "calling")   return TrespasserCallingDialog.wait(sourceItem, this.actor);
+    if (sourceItem.type === "craft")     return TrespasserCraftDialog.wait(sourceItem, this.actor);
+    if (sourceItem.type === "past_life") return this._applyPastLife(sourceItem);
+    return super._onDropItem(event, dropped);
+  }
 
-      if (success) {
-        console.log(`Trespasser | _onDropItem (Haven Transfer): Emitting HAVEN_WITHDRAWAL socket for index ${data.havenIndex}`);
-        // Notify through socket to update Haven (handles permissions)
-        TrespasserSocket.emit("HAVEN_WITHDRAWAL", {
-          havenUuid: sourceHaven.uuid,
-          index: data.havenIndex,
-          targetActorUuid: this.actor.uuid,
-          transferAll: !!data.transferAll
-        });
-        
-        ui.notifications.info(game.i18n.format("TRESPASSER.Notification.Transfer.Complete", {
-          item: entry.item.name,
-          target: this.actor.name
-        }));
-      }
-      
-      return false;
-    }
+  /**
+   * Reorder an item dropped onto another row of the same sheet. Inventory
+   * lists render in sort order, so adjust sort values relative to the row
+   * under the drop point.
+   */
+  async #onSortItem(event, item) {
+    const targetEl = event.target?.closest?.("[data-item-id]");
+    const target = targetEl ? this.actor.items.get(targetEl.dataset.itemId) : null;
+    if (!target || target.id === item.id) return false;
 
-    const item = await Item.implementation.fromDropData(data);
-    if (!item) return super._onDropItem(event, data);
-
-    if (item.type === "calling") return TrespasserCallingDialog.wait(item, this.actor);
-    if (item.type === "craft")   return TrespasserCraftDialog.wait(item, this.actor);
-    if (item.type === "past_life") return this._applyPastLife(item);
-    return super._onDropItem(event, data);
+    const siblings = this.actor.items.filter(i => i.id !== item.id);
+    const updates = foundry.utils.performIntegerSort(item, { target, siblings });
+    return this.actor.updateEmbeddedDocuments("Item", updates.map(u => ({ _id: u.target.id, sort: u.update.sort })));
   }
 
   // ── Delegate methods (kept here so Foundry's .bind(this) chains work) ─────

--- a/module/sheets/actor-creature-sheet.mjs
+++ b/module/sheets/actor-creature-sheet.mjs
@@ -166,12 +166,58 @@ export class TrespasserCreatureSheet extends api.HandlebarsApplicationMixin(shee
       const item = this.actor.items.get(el.dataset.itemId);
       item?.sheet.render(true);
     });
+
+    this.#bindItemDragHandlers();
+
+    // Fallback drop handling: core's v14 sheet pipeline does not reliably
+    // bind drop handlers to this sheet's markup, so accept item drops at
+    // the root. The handled-stamp prevents double-processing if core also
+    // routes the same event.
+    if (!this.element._trespasserRootDropBound) {
+      this.element._trespasserRootDropBound = true;
+      this.element.addEventListener("dragover", ev => ev.preventDefault());
+      this.element.addEventListener("drop", async ev => {
+        if (ev._trespasserItemDropHandled) return;
+        const data = foundry.applications.ux.TextEditor.implementation.getDragEventData(ev);
+        if (data?.type !== "Item") return;
+        const item = await Item.implementation.fromDropData(data);
+        if (!item || item.parent === this.actor) return;
+        ev._trespasserItemDropHandled = true;
+        if (!this.actor.isOwner) return;
+        await this.actor.createEmbeddedDocuments("Item", [item.toObject()]);
+        // The creature sheet only displays some item types, so confirm the
+        // drop in a notification regardless of what was added.
+        ui.notifications.info(game.i18n.format("TRESPASSER.Notification.Item.Added", {
+          item: item.name, target: this.actor.name
+        }));
+      });
+    }
+  }
+
+  /**
+   * Make item rows draggable with standard Foundry drag data. Core's v14
+   * sheet drag-drop rework no longer binds drag handlers to system markup,
+   * so the sheet wires its own dragstart listeners.
+   */
+  #bindItemDragHandlers() {
+    for (const el of this.element.querySelectorAll('[draggable="true"]')) {
+      if (el._trespasserDragBound) continue;
+      el._trespasserDragBound = true;
+      el.addEventListener("dragstart", ev => {
+        const id = el.dataset.itemId ?? el.closest("[data-item-id]")?.dataset.itemId;
+        const item = id ? this.actor.items.get(id) : null;
+        if (!item) return;
+        ev.dataTransfer.setData("text/plain", JSON.stringify(item.toDragData()));
+      });
+    }
   }
 
   /** @override */
-  async _onDropItem(event, data) {
+  async _onDropItem(event, dropped) {
+    if (event._trespasserItemDropHandled) return false;
+    event._trespasserItemDropHandled = true;
     if (!this.actor.isOwner) return false;
-    return super._onDropItem(event, data);
+    return super._onDropItem(event, dropped);
   }
 
   async _onItemCreate(event) {
@@ -240,7 +286,7 @@ export class TrespasserCreatureSheet extends api.HandlebarsApplicationMixin(shee
     const item = this.actor.items.get(li.dataset.itemId);
     if (!item) return;
 
-    const enrichedRef = await TextEditor.enrichHTML(item.system.description, {
+    const enrichedRef = await foundry.applications.ux.TextEditor.implementation.enrichHTML(item.system.description, {
       async: true,
       secrets: item.isOwner,
       relativeTo: item

--- a/module/sheets/actor-dungeon-sheet.mjs
+++ b/module/sheets/actor-dungeon-sheet.mjs
@@ -7,6 +7,8 @@
  * are implemented directly.
  */
 
+import { messageVisibility } from "../helpers/compat.mjs";
+
 const { api, sheets } = foundry.applications;
 
 export class TrespasserDungeonSheet extends api.HandlebarsApplicationMixin(sheets.ActorSheetV2) {
@@ -165,7 +167,7 @@ export class TrespasserDungeonSheet extends api.HandlebarsApplicationMixin(sheet
           }
           return {
             diceRange: rangeStr,
-            text: r.name || r.text || "—",
+            text: r.name || r.description || "—",
             img: r.img || null
           };
         });
@@ -289,7 +291,7 @@ export class TrespasserDungeonSheet extends api.HandlebarsApplicationMixin(sheet
     if (!tableId) return;
     const table = game.tables.get(tableId);
     if (!table) return;
-    await table.draw({ rollMode: CONST.DICE_ROLL_MODES.PRIVATE });
+    await table.draw(messageVisibility("gm"));
   }
 
   static async #onCreateEncounterTable(event, target) {
@@ -306,7 +308,7 @@ export class TrespasserDungeonSheet extends api.HandlebarsApplicationMixin(sheet
   /* -------------------------------------------- */
 
   async _onDrop(event) {
-    const data = TextEditor.getDragEventData(event);
+    const data = foundry.applications.ux.TextEditor.implementation.getDragEventData(event);
     if (data?.type === "RollTable") {
       if (!this.isEditable) return false;
       const table = await RollTable.implementation.fromDropData(data);
@@ -319,7 +321,8 @@ export class TrespasserDungeonSheet extends api.HandlebarsApplicationMixin(sheet
 
   async _onDropItem(event, data) {
     if (!this.isEditable) return false;
-    const item = await Item.implementation.fromDropData(data);
+    // v14 passes the resolved Item document; raw drag data still resolves
+    const item = data instanceof Item ? data : await Item.implementation.fromDropData(data ?? {});
     if (!item) return false;
 
     // Only allow room items on dungeons

--- a/module/sheets/actor-haven-sheet.mjs
+++ b/module/sheets/actor-haven-sheet.mjs
@@ -302,6 +302,17 @@ export class TrespasserHavenSheet extends api.HandlebarsApplicationMixin(sheets.
       });
     });
 
+    // Fallback: accept item drops anywhere on the sheet, not only on the
+    // designated zones. Zone handlers stopPropagation, so drops that land
+    // on a zone are not handled twice. #onDrop reads dataset.action off the
+    // event's currentTarget, which is undefined here, routing the drop to
+    // the general inventory-deposit branch.
+    if (!this.element._trespasserRootDropBound) {
+      this.element._trespasserRootDropBound = true;
+      this.element.addEventListener('dragover', (ev) => ev.preventDefault());
+      this.element.addEventListener('drop', (ev) => this.#onDrop(ev));
+    }
+
     // Handle dragging items from inventory
     html.querySelectorAll('.inventory-item.item').forEach(li => {
       li.addEventListener('dragstart', (ev) => this.#onDragStart(ev));
@@ -320,6 +331,17 @@ export class TrespasserHavenSheet extends api.HandlebarsApplicationMixin(sheets.
   /* Drag & Drop                                  */
   /* -------------------------------------------- */
 
+  /**
+   * Items enter a Haven only through #onDrop's deposit logic (custom
+   * inventory) or its embedded-type branch. Disable the default sheet
+   * behavior, which would create an embedded Item this sheet never
+   * displays — on v13, core's own drop pipeline runs alongside the
+   * sheet's listeners and would otherwise duplicate deposits.
+   */
+  async _onDropItem() {
+    return false;
+  }
+
   async #onDrop(event) {
     console.log("Trespasser | TrespasserHavenSheet.#onDrop: Entry");
     event.preventDefault();
@@ -327,7 +349,7 @@ export class TrespasserHavenSheet extends api.HandlebarsApplicationMixin(sheets.
     const zone = event.currentTarget;
     const action = zone.dataset.action;
     
-    const data = TextEditor.getDragEventData(event);
+    const data = foundry.applications.ux.TextEditor.implementation.getDragEventData(event);
     
     if (action === "dropLeader") {
       if (data.type !== "Actor") return;

--- a/module/sheets/actor-party-sheet.mjs
+++ b/module/sheets/actor-party-sheet.mjs
@@ -503,7 +503,8 @@ export class TrespasserPartySheet extends api.HandlebarsApplicationMixin(sheets.
 
   async _onDropActor(event, data) {
     if (!this.isEditable) return false;
-    const actor = await Actor.implementation.fromDropData(data);
+    // v14 passes the resolved Actor document; raw drag data still resolves
+    const actor = data instanceof Actor ? data : await Actor.implementation.fromDropData(data ?? {});
     if (!actor || actor.type !== "character") {
       ui.notifications.warn(game.i18n.localize("TRESPASSER.Notification.Party.DropCharactersOnly"));
       return false;

--- a/module/sheets/chracter/get-data.mjs
+++ b/module/sheets/chracter/get-data.mjs
@@ -1,0 +1,404 @@
+/**
+ * Character Sheet — getData helper
+ * Exports: getCharacterData(sheet, options)
+ */
+
+import { TrespasserEffectsHelper } from "../../helpers/effects-helper.mjs";
+import { PASSIVE_STATES } from "../../config/state-config.mjs";
+import { COMMON_PLIGHTS } from "../../config/plight-config.mjs";
+
+export async function getCharacterData(sheet, options = {}) {
+  const actor   = sheet.actor;
+  const context = {
+    actor,
+    system: actor.system,
+    flags: actor.flags,
+    editable: sheet.isEditable,
+    owner: actor.isOwner,
+  };
+
+  // Categorize effects using helper
+  context.activeEffects = TrespasserEffectsHelper.getActorEffects(actor);
+  context.durationModes = TrespasserEffectsHelper.DURATION_LABELS;
+
+  // Skill labels for the sheet
+  const skills = context.system.skills || {};
+  context.skillList = Object.entries(skills).map(([key, value]) => ({
+    key,
+    label: game.i18n.localize(`TRESPASSER.Terms.Skill.${key.charAt(0).toUpperCase() + key.slice(1)}`),
+    value,
+  }));
+
+  // Calculate total attributes including effect bonuses for display
+  context.totalAttributes = {};
+  for (const attr of ["mighty", "agility", "intellect", "spirit"]) {
+    const base = context.system.attributes[attr] ?? 0;
+    const bonus = TrespasserEffectsHelper.getAttributeBonus(actor, attr, "use");
+    context.totalAttributes[attr] = base + bonus;
+  }
+
+  // Combat and Resource totals (already derived in the DataModel)
+  context.totalCombat = {
+    ...context.system.combat,
+    armor: context.system.armor,
+    max_health: context.system.max_health,
+    max_endurance: context.system.max_endurance
+  };
+  context.speedBonus = context.system.combat.speed_bonus ?? 2;
+  context.totalCombat.speed_bonus = context.system.combat.speed_bonus;
+
+  // Fixed 3-slot craft array
+  const crafts = context.system.crafts ?? [];
+  context.craftsSlots = [crafts[0] ?? "", crafts[1] ?? "", crafts[2] ?? ""];
+
+  // Always show exactly 2 alignment rows
+  const emptyAlignment = () => ({ name: "", leftBoxes: [false, false, false], rightBoxes: [false, false, false] });
+  const rawAlignment   = Array.isArray(context.system.alignment) ? context.system.alignment : [];
+  context.system.alignment = [
+    (rawAlignment[0] && typeof rawAlignment[0] === "object") ? rawAlignment[0] : emptyAlignment(),
+    (rawAlignment[1] && typeof rawAlignment[1] === "object") ? rawAlignment[1] : emptyAlignment()
+  ];
+
+  const injuryItems = actor.items.filter(i => i.type === "injury");
+  for (const inj of injuryItems) {
+    const total  = Math.max(2, inj.system.injuryClock);
+    const filled = Math.min(inj.system.currentClock, total);
+    inj.clockSegments = buildClockSegments(total, filled);
+  }
+  context.injurySlots = [injuryItems[0] ?? null, injuryItems[1] ?? null, injuryItems[2] ?? null];
+  context.injuryCount = injuryItems.length;
+
+  // Items by category
+  context.features  = actor.items.filter(i => i.type === "feature");
+  context.talents   = actor.items.filter(i => i.type === "talent").map(t => {
+    const talentData = t.toObject ? t.toObject(false) : t.toJSON();
+    talentData.id = t.id;
+    const baseCost  = talentData.system.focusCost || 0;
+    const bonusCost = talentData.system.bonusCost || 0;
+    talentData.displayCost = baseCost + bonusCost;
+    const callingSource = t.flags?.trespasser?.callingSource;
+    if (callingSource) talentData.callingSource = callingSource;
+    return talentData;
+  });
+  context.incantations = actor.items.filter(i => i.type === "incantation");
+
+  // Plights
+  context.plights = actor.items
+    .filter(i => i.type === "plight")
+    .map(item => {
+      const config = COMMON_PLIGHTS[item.system.plightId];
+      return {
+        id: item.id,
+        name: item.name,
+        plightId: item.system.plightId,
+        description: item.system.description,
+        icon: config?.icon || "fas fa-exclamation-triangle",
+        tint: config?.tint || "#aaa",
+        isCustom: !item.system.plightId
+      };
+    });
+
+  // Lasting States (effects with isLasting = true)
+  context.lastingStates = actor.items
+    .filter(i => i.type === "effect" && i.system.isLasting)
+    .map(item => ({
+      id: item.id,
+      name: item.name,
+      intensity: item.system.intensity || 0,
+      modifier: item.system.modifier,
+      target: item.system.targetAttribute,
+      description: item.system.description
+    }));
+
+  // Actions and Reactions for Combat Tab
+  const combatActions = [];
+  const combatReactions = [];
+
+  context.features.forEach(f => {
+    if (f.system.type === "action") combatActions.push(f);
+    else if (f.system.type === "reaction") combatReactions.push(f);
+  });
+
+  context.talents.forEach(t => {
+    if (t.system.type === "action") combatActions.push(t);
+    else if (t.system.type === "reaction") combatReactions.push(t);
+  });
+
+  context.combatActions = combatActions;
+  context.combatReactions = combatReactions;
+  context.hasCombatActionsOrReactions = combatActions.length > 0 || combatReactions.length > 0;
+
+  const sourceMapByUuid = {};
+  for (const item of actor.items) {
+    if (item.type === "feature") {
+      (item.system.deeds || []).forEach(d => { if (d.uuid) sourceMapByUuid[d.uuid] = item.name; });
+      (item.system.effects || []).forEach(e => { if (e.uuid) sourceMapByUuid[e.uuid] = item.name; });
+    } else if (item.type === "weapon" && item.system.equipped) {
+      (item.system.extraDeeds || []).forEach(d => { if (d.uuid) sourceMapByUuid[d.uuid] = item.name; });
+      (item.system.effects || []).forEach(e => { if (e.uuid) sourceMapByUuid[e.uuid] = item.name; });
+      (item.system.enhancementEffects || []).forEach(e => { if (e.uuid) sourceMapByUuid[e.uuid] = item.name; });
+    } else if (item.type === "armor" && item.system.equipped) {
+      (item.system.effects || []).forEach(e => { if (e.uuid) sourceMapByUuid[e.uuid] = item.name; });
+    }
+    const callingSource = item.flags?.trespasser?.callingSource;
+    if (callingSource) item.callingSource = callingSource;
+  }
+
+  // Group deeds by tier
+  const allDeeds = actor.items.filter(i => i.type === "deed").map(d => {
+    const deedData = d.toObject ? d.toObject(false) : d.toJSON();
+    deedData.id = d.id;
+
+    const tier = deedData.system.tier;
+    let baseCost = deedData.system.focusCost;
+    if (baseCost === null || baseCost === undefined) {
+      if (tier === "heavy") baseCost = 2;
+      else if (tier === "mighty") baseCost = 4;
+      else baseCost = 0;
+    }
+
+    let costIncrease = deedData.system.focusIncrease;
+    if (costIncrease === null || costIncrease === undefined) {
+      if (tier === "heavy" || tier === "mighty") costIncrease = 1;
+      else costIncrease = 0;
+    }
+
+    const bonusCost = deedData.system.bonusCost || 0;
+    const uses      = deedData.system.uses || 0;
+    deedData.displayCost = baseCost + bonusCost;
+    deedData.showCost    = deedData.displayCost > 0;
+    deedData.hasUses     = costIncrease > 0;
+
+    if (deedData.hasUses) {
+      deedData.usesCheckboxes = Array.from({ length: 3 }, (_, i) => ({ index: i + 1, checked: i < uses }));
+    }
+
+    const linkedSource = d.flags?.trespasser?.linkedSource;
+    if (linkedSource && sourceMapByUuid[linkedSource]) {
+      deedData.sourceName = sourceMapByUuid[linkedSource];
+    }
+
+    return deedData;
+  });
+
+  context.deedsGrouped = {
+    light:   allDeeds.filter(d => d.system.tier === "light"),
+    heavy:   allDeeds.filter(d => d.system.tier === "heavy"),
+    mighty:  allDeeds.filter(d => d.system.tier === "mighty"),
+    special: allDeeds.filter(d => d.system.tier === "special")
+  };
+  context.deeds = allDeeds;
+
+  // Only physical inventory types appear in inventory, ordered by sort
+  // so drag-reordering is reflected in the rendered lists
+  const inventoryTypes = ["weapon", "armor", "accessory", "rations", "item"];
+  const allInventoryItems = actor.items.filter(i => inventoryTypes.includes(i.type))
+    .sort((a, b) => (a.sort ?? 0) - (b.sort ?? 0));
+  context.unequippedItems = allInventoryItems.filter(i => !i.system.equipped);
+  context.equippedItems   = allInventoryItems.filter(i => i.system.equipped);
+
+  const totalOccupancy = context.unequippedItems.reduce((acc, i) => {
+    const val = i.system.slotOccupancy !== undefined ? parseFloat(i.system.slotOccupancy) : 1;
+    return acc + (isNaN(val) ? 1 : val);
+  }, 0);
+  context.inventorySlotsUsed = totalOccupancy % 1 === 0 ? totalOccupancy : totalOccupancy.toFixed(1);
+  context.inventory = context.unequippedItems;
+
+  // Equipped Armor
+  context.equippedArmor = {};
+  const armorSlots = ["head", "body", "arms", "legs", "outer", "shield"];
+  for (const slot of armorSlots) {
+    const item = actor.items.find(i => (i.type === "armor" || (i.type === "item" && i.system.equippable)) && i.system.equipped && i.system.placement === slot);
+    if (item) {
+        if (item.type === "armor") {
+            item.effectSummary = (item.system.effects || []).map(e => e.name).join(", ") || "—";
+        } else {
+            // Generic item effect summary
+            item.effectSummary = [
+                ...(item.system.talents  || []).map(e => e.name),
+                ...(item.system.features || []).map(e => e.name),
+                ...(item.system.deeds    || []).map(e => e.name),
+                ...(item.system.effects  || []).map(e => e.name),
+                ...(item.system.incantations || []).map(e => e.name)
+            ].join(", ") || "—";
+        }
+    }
+    context.equippedArmor[slot] = item || null;
+  }
+
+  // Equipped Accessories
+  context.equippedAccessories = {};
+  const accessorySlots = ["amulet", "ring", "talisman"];
+  for (const slot of accessorySlots) {
+    const item = actor.items.find(i => (i.type === "accessory" || (i.type === "item" && i.system.equippable)) && i.system.equipped && i.system.placement === slot);
+    if (item) {
+      item.effectSummary = [
+        ...(item.system.talents  || []).map(e => e.name),
+        ...(item.system.features || []).map(e => e.name),
+        ...(item.system.deeds    || []).map(e => e.name),
+        ...(item.system.effects  || []).map(e => e.name),
+        ...(item.system.incantations || []).map(e => e.name)
+      ].join(", ") || "—";
+    }
+    context.equippedAccessories[slot] = item || null;
+  }
+
+  // Equipped Weapons
+  const mainHandId = context.system.equipment?.main_hand;
+  const offHandId  = context.system.equipment?.off_hand;
+  context.equippedWeapon = {
+    main_hand: mainHandId ? actor.items.get(mainHandId) : null,
+    off_hand:  offHandId  ? actor.items.get(offHandId)  : null
+  };
+
+  if (context.equippedWeapon.main_hand) {
+    const item = context.equippedWeapon.main_hand;
+    item.effectSummary = [
+      ...(item.system.effects || []).map(e => e.name),
+      ...(item.system.enhancementEffects || []).map(e => e.name),
+      ...(item.system.talents || []).map(e => e.name),
+      ...(item.system.features || []).map(e => e.name),
+      ...(item.system.deeds    || []).map(e => e.name),
+      ...(item.system.incantations || []).map(e => e.name)
+    ].join(", ") || "—";
+  }
+  if (context.equippedWeapon.off_hand) {
+    const item = context.equippedWeapon.off_hand;
+    item.effectSummary = [
+      ...(item.system.effects || []).map(e => e.name),
+      ...(item.system.enhancementEffects || []).map(e => e.name),
+      ...(item.system.talents || []).map(e => e.name),
+      ...(item.system.features || []).map(e => e.name),
+      ...(item.system.deeds    || []).map(e => e.name),
+      ...(item.system.incantations || []).map(e => e.name)
+    ].join(", ") || "—";
+  }
+
+  context.inventoryMax = context.system.inventory_max ?? 5;
+
+  // Weapon Modes
+  const weaponModes = [];
+  const mainWeapon = context.equippedWeapon.main_hand?.type === "weapon" ? context.equippedWeapon.main_hand : null;
+  const offWeapon  = context.equippedWeapon.off_hand?.type  === "weapon" ? context.equippedWeapon.off_hand  : null;
+
+  if (mainWeapon && offWeapon && mainWeapon.id === offWeapon.id) {
+    weaponModes.push({ key: "main", label: `${game.i18n.localize("TRESPASSER.Terms.Combat.TwoHanded")}: ${mainWeapon.name}` });
+  } else {
+    if (mainWeapon) weaponModes.push({ key: "main", label: `${game.i18n.localize("TRESPASSER.Terms.Combat.MainHand")}: ${mainWeapon.name}` });
+    if (offWeapon)  weaponModes.push({ key: "off",  label: `${game.i18n.localize("TRESPASSER.Terms.Combat.OffHand")}: ${offWeapon.name}` });
+    if (mainWeapon && offWeapon) weaponModes.push({ key: "dual", label: game.i18n.localize("TRESPASSER.Terms.Combat.DualWield") });
+  }
+  context.weaponModes = weaponModes;
+
+  // Active Weapon Snapshot
+  let activeWeapon = { die: "—", effect: "—", name: "—" };
+  const mode = context.system.combat.weaponMode || "main";
+
+  if (mode === "dual" && mainWeapon && offWeapon) {
+    const mainDie = mainWeapon.system.weaponDie || "d4";
+    const offDie  = offWeapon.system.weaponDie  || "d4";
+    const mainDieValue = parseInt(String(mainDie).replace("d", "")) || 0;
+    const offDieValue  = parseInt(String(offDie).replace("d", ""))  || 0;
+    activeWeapon.die    = mainDieValue >= offDieValue ? mainDie : offDie;
+    activeWeapon.name   = `${mainWeapon.name} & ${offWeapon.name}`;
+    activeWeapon.effect = `${mainWeapon.effectSummary} / ${offWeapon.effectSummary}`;
+  } else if (mode === "off" && offWeapon) {
+    activeWeapon.die    = offWeapon.system.weaponDie;
+    activeWeapon.name   = offWeapon.name;
+    activeWeapon.effect = offWeapon.effectSummary;
+  } else if (mainWeapon) {
+    activeWeapon.die    = mainWeapon.system.weaponDie;
+    activeWeapon.name   = mainWeapon.name;
+    activeWeapon.effect = mainWeapon.effectSummary;
+  } else if (offWeapon) {
+    activeWeapon.die    = offWeapon.system.weaponDie;
+    activeWeapon.name   = offWeapon.name;
+    activeWeapon.effect = offWeapon.effectSummary;
+  }
+  context.activeWeapon = activeWeapon;
+
+  context.keyAttribute = context.system.key_attribute ?? "mighty";
+
+  // Transfer Target check
+  const targets = game.user.targets;
+  if (targets.size === 1) {
+    const targetToken = targets.first();
+    const targetActor = targetToken.actor;
+    if (targetActor) {
+      if (targetActor.type === "haven") {
+        context.transferTarget = {
+          id: targetActor.id,
+          name: targetActor.name,
+          type: "haven"
+        };
+      } else if (targetActor.type === "character" && targetActor.id !== actor.id) {
+        context.transferTarget = {
+          id: targetActor.id,
+          name: targetActor.name,
+          type: "character"
+        };
+      }
+    }
+  }
+
+  // Enrich Notes
+  context.enrichedNotes = await foundry.applications.ux.TextEditor.implementation.enrichHTML(actor.system.notes ?? "", {
+    async: true,
+    secrets: actor.isOwner,
+    relativeTo: actor,
+    rollData: actor.getRollData()
+  });
+
+  context.passiveStates = Object.entries(PASSIVE_STATES)
+    .map(([key, cfg]) => ({
+      key,
+      active: actor.system.passiveStates?.[key] ?? false,
+      icon: cfg.icon,
+      label: cfg.label,
+      description: cfg.description
+    }))
+    .filter(s => actor.type === "character" || s.key !== "encumbered");
+
+  // Build plight overlay icons
+  context.plightOverlay = {};
+  for (const item of actor.items) {
+    if (item.type !== "plight") continue;
+    const config = COMMON_PLIGHTS[item.system.plightId];
+    if (config) {
+      context.plightOverlay[item.system.plightId] = {
+        active: true,
+        icon: config.icon,
+        label: config.label,
+        description: config.description,
+        tint: config.tint
+      };
+    }
+  }
+
+  return context;
+}
+
+/**
+ * Build SVG clock segment paths for an injury item.
+ * Exported so handlers-misc can reuse it.
+ */
+export function buildClockSegments(total, filled) {
+  const cx = 50, cy = 50, r = 44;
+  const segments = [];
+  const angleStep  = (2 * Math.PI) / total;
+  const startOffset = -Math.PI / 2;
+
+  for (let i = 0; i < total; i++) {
+    const a1 = startOffset + i * angleStep;
+    const a2 = startOffset + (i + 1) * angleStep;
+    const gap = 0;
+    const x4 = (cx + r * Math.cos(a1 + gap)).toFixed(2);
+    const y4 = (cy + r * Math.sin(a1 + gap)).toFixed(2);
+    const x3 = (cx + r * Math.cos(a2 - gap)).toFixed(2);
+    const y3 = (cy + r * Math.sin(a2 - gap)).toFixed(2);
+    const largeArc = (a2 - a1) > Math.PI ? 1 : 0;
+    const path = `M ${cx} ${cy} L ${x4} ${y4} A ${r} ${r} 0 ${largeArc} 1 ${x3} ${y3} Z`;
+    segments.push({ path, filled: i < filled });
+  }
+  return segments;
+}

--- a/module/sheets/chracter/handlers-deed.mjs
+++ b/module/sheets/chracter/handlers-deed.mjs
@@ -1,0 +1,968 @@
+/**
+ * Character Sheet — Deed roll handlers
+ * onDeedRoll       — orchestrator, called from both sheet and HUD
+ * rollCharacterDeed — character targeting a creature
+ * rollCreatureDeed  — creature targeting a character
+ * postDeedPhase    — chat output for a single deed phase
+ */
+
+import { TrespasserEffectsHelper } from "../../helpers/effects-helper.mjs";
+import { TrespasserCombat }        from "../../documents/combat.mjs";
+import { TrespasserRollDialog }    from "../../dialogs/roll-dialog.mjs";
+import { TargetingHelper }         from "../../helpers/targeting-helper.mjs";
+import { askSparkDialog }          from "../../dialogs/spark-dialog.mjs";
+import { requestPlayerDefenseRoll } from "../../helpers/defense-roll-helper.mjs";
+import { messageVisibility }        from "../../helpers/compat.mjs";
+
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Deed card chat message
+// ─────────────────────────────────────────────────────────────────────────────
+
+async function postDeedCard(actor, item) {
+  const sys = item.system;
+  const phases = ["start", "before", "base", "hit", "spark", "after", "end"];
+  const allPhases = phases.map(key => ({
+    key,
+    label: game.i18n.localize(`TRESPASSER.Terms.DeedPhases.${key.charAt(0).toUpperCase() + key.slice(1)}`),
+    data: sys.effects?.[key] ?? {}
+  }));
+  const cardPhases = allPhases.filter(p => p.data.description);
+
+  const tier = sys.tier;
+  let baseCost = sys.focusCost;
+  if (baseCost === null || baseCost === undefined) {
+    if (tier === "heavy") baseCost = 2;
+    else if (tier === "mighty") baseCost = 4;
+    else baseCost = 0;
+  }
+  const displayCost = baseCost + (sys.bonusCost || 0);
+
+  const content = await foundry.applications.handlebars.renderTemplate(
+    "systems/trespasser/templates/chat/deed-card.hbs",
+    {
+      name: item.name,
+      tierLabel: game.i18n.localize(`TRESPASSER.Sheet.Item.Details.Tiers.${tier.charAt(0).toUpperCase() + tier.slice(1)}`),
+      type: sys.type,
+      actionType: sys.actionType,
+      accuracyTest: sys.accuracyTest,
+      target: sys.target,
+      displayCost,
+      showCost: displayCost > 0,
+      cardPhases
+    }
+  );
+
+  await ChatMessage.create({
+    speaker: ChatMessage.getSpeaker({ actor }),
+    content
+  });
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Main orchestrator
+// ─────────────────────────────────────────────────────────────────────────────
+
+export async function onDeedRoll(event, sheet) {
+  event.preventDefault();
+  const el = event.currentTarget.closest("[data-item-id]");
+  if (!el) return;
+  const item = sheet.actor.items.get(el.dataset.itemId);
+  if (!item) return;
+
+  const isAttack  = item.system.actionType !== "support";
+  const isCreature = sheet.actor.type === "creature";
+
+  // ── 1. Ammo check (characters only) ───────────────────────────────────────
+  let ammoToConsumeId = null;
+  if (!isCreature) {
+    const activeWeapons = sheet._getActiveWeapons();
+    const isMissileDeed = item.system.type === "missile" ||
+      (item.system.type === "versatile" && activeWeapons.some(w => w.system.type === "missile"));
+
+    if (isMissileDeed) {
+      for (const w of activeWeapons) {
+        if (w.system.type === "missile" && w.system.needsAmmo) {
+          const ammoItems = sheet.actor.items.filter(i => i.system.isAmmo);
+          if (ammoItems.length === 0) {
+            ui.notifications.error(game.i18n.localize("TRESPASSER.Notification.Combat.NoAmmo"));
+            return;
+          }
+          ammoToConsumeId = await sheet._selectAmmoDialog(ammoItems, w);
+          if (!ammoToConsumeId) return;
+          break;
+        }
+      }
+    }
+  }
+
+  // ── 1b. Weapon compatibility check (characters only) ──────────────────────
+  if (!isCreature) {
+    const wpnCheck = TargetingHelper.validateWeaponCompatibility(
+      item.system, sheet._getActiveWeapons(), sheet.actor
+    );
+    if (!wpnCheck.valid) {
+      ui.notifications.warn(wpnCheck.message);
+      return;
+    }
+  }
+
+  // ── 2. Focus cost & Surcharge ──────────────────────────────────────────────
+  const combatant   = TrespasserCombat.getPhaseCombatant(sheet.actor);
+  const usedActions = new Set(combatant?.getFlag("trespasser", "usedHUDActions") ?? []);
+  const surcharge   = usedActions.has("maneuver") ? 2 : 0;
+
+  const tier = item.system.tier;
+  let baseCost = item.system.focusCost;
+  if (baseCost === null || baseCost === undefined) {
+    if (tier === "heavy") baseCost = 2;
+    else if (tier === "mighty") baseCost = 4;
+    else baseCost = 0;
+  }
+  let costIncrease = item.system.focusIncrease;
+  if (costIncrease === null || costIncrease === undefined) {
+    costIncrease = (tier === "heavy" || tier === "mighty") ? 1 : 0;
+  }
+  const currentBonusCost = item.system.bonusCost || 0;
+  const currentUses      = item.system.uses || 0;
+  const totalCost        = baseCost + currentBonusCost + surcharge;
+
+  const restrictAPF = game.settings.get("trespasser", "restrictAPFocusUsage");
+  if (totalCost > 0) {
+    const currentFocus = sheet.actor.system.combat.focus || 0;
+    if (restrictAPF && currentFocus < totalCost) {
+      ui.notifications.error(game.i18n.format("TRESPASSER.Notification.Combat.NotEnoughFocus",
+        { name: item.name, cost: totalCost, current: currentFocus }));
+      return;
+    }
+  }
+
+  // ── 3. Target resolution (AOE-aware) ──────────────────────────────────────
+  const deed = item.system;
+  let targets;
+  let templateDoc = null;
+
+  // Resolve the caster's token for AOE placement
+  const sourceToken = sheet.actor.token?.object || 
+                     canvas.tokens.controlled.find(t => t.actor?.id === sheet.actor.id) ||
+                     canvas.tokens.placeables.find(t => t.actor?.id === sheet.actor.id);
+
+  if (deed.targetType === "personal") {
+    // Personal: auto-target self
+    targets = sourceToken ? [sourceToken] : [];
+  } else if (["blast", "close_blast", "burst", "melee_burst", "path", "close_path", "aura"]
+             .includes(deed.targetType)) {
+    // AOE: place template and resolve targets from grid squares
+    if (!sourceToken) {
+      ui.notifications.warn(game.i18n.localize("TRESPASSER.Notification.Combat.NoTokenOnCanvas"));
+      return;
+    }
+
+    const activeWeapons = typeof sheet._getActiveWeapons === "function" ? sheet._getActiveWeapons() : [];
+    const aoeResult = await TargetingHelper.placeTemplate(sheet.actor, sourceToken, deed, activeWeapons);
+    if (!aoeResult) return; // cancelled
+    templateDoc = aoeResult.templateDoc;
+    const gridPx = canvas.grid.size;
+    targets = TargetingHelper.getTokensInSquares(aoeResult.squares, gridPx, {
+      excludeTokenId: isAttack ? sourceToken.id : null
+    });
+  } else {
+    // "creature" type — use manual targeting with validation
+    targets = Array.from(game.user.targets);
+    const validation = TargetingHelper.validateTargets(targets, deed, sourceToken);
+    if (!validation.valid) {
+      ui.notifications.warn(validation.message);
+      return;
+    }
+    if (isAttack && targets.length === 0) {
+      ui.notifications.warn(game.i18n.localize("TRESPASSER.Notification.Combat.NoTargetsDefault"));
+      return;
+    }
+
+    // Range validation
+    if (sourceToken) {
+      let rangeCheck = { valid: true };
+      
+      if (isCreature) {
+        // Creatures: Check range ONLY if deed.range is set
+        if (deed.range !== null) {
+          rangeCheck = TargetingHelper.validateRange(targets, sourceToken, deed, []);
+        }
+      } else {
+        // Characters: Existing weapon-based range check
+        const activeWeapons = sheet._getActiveWeapons() || [];
+        rangeCheck = TargetingHelper.validateRange(targets, sourceToken, deed, activeWeapons);
+      }
+      
+      if (!rangeCheck.valid) {
+        const disregardRange = game.settings.get("trespasser", "disregardRangeOnAttack");
+        ui.notifications.warn(rangeCheck.message);
+        if (!disregardRange) return;
+      }
+    }
+  }
+
+  // ── 4. Resolve AP ─────────────────────────────────────────────────────────
+  let apSpent = 1;
+  let apBonus = 0;
+
+  if (combatant) {
+    const availableAP = combatant.getFlag("trespasser", "actionPoints") ?? 0;
+    if (restrictAPF && availableAP < 1) {
+      ui.notifications.warn(game.i18n.localize("TRESPASSER.Notification.Combat.NotEnoughAP"));
+      return;
+    }
+    if (availableAP > 1 && sheet._askAPDialog) {
+      apSpent = await sheet._askAPDialog(availableAP);
+      if (apSpent === null) return; // cancelled
+    }
+    apBonus = (apSpent - 1) * 2;
+  }
+
+  // ── 4.5. Roll Dialog (Characters only) ────────────────────────────────────
+  let userModifier = 0;
+  if (!isCreature) {
+    const isAdv          = TrespasserEffectsHelper.hasAdvantage(sheet.actor, "accuracy");
+    const effectBonus    = TrespasserEffectsHelper.getAttributeBonus(sheet.actor, "accuracy", "use");
+    const totalAccuracy  = sheet.actor.system.combat.accuracy ?? 0;
+    const baseAccuracy   = totalAccuracy - effectBonus;
+    const diceFormula    = isAdv ? "2d20kh" : "1d20";
+
+    const rollData = {
+      dice: diceFormula,
+      bonuses: [
+        { label: game.i18n.localize("TRESPASSER.Sheet.Combat.Accuracy"), value: baseAccuracy },
+        { label: game.i18n.localize("TRESPASSER.Dialog.Roll.EffectBonus"), value: effectBonus }
+      ]
+    };
+    if (apBonus > 0) rollData.bonuses.push({ label: game.i18n.localize("TRESPASSER.Chat.Check.AccuracyFromAP"), value: apBonus });
+
+    const result = await TrespasserRollDialog.wait({
+      ...rollData,
+      showCD: false
+    }, { title: `${item.name} Roll` });
+    if (!result) return;
+    userModifier = result.modifier;
+  }
+
+  // ── 4.6. Final side-effects (Focus, Ammo) ─────────────────────────────────
+  if (!isCreature) {
+    if (totalCost > 0) {
+      const currentFocus = sheet.actor.system.combat.focus || 0;
+      await sheet.actor.update({ "system.combat.focus": Math.max(0, currentFocus - totalCost) });
+      if (surcharge > 0 && restrictAPF) {
+        ChatMessage.create({
+          speaker: ChatMessage.getSpeaker({ actor: sheet.actor }),
+          content: `<strong>${sheet.actor.name}</strong> ${game.i18n.format("TRESPASSER.Chat.Action.DeedSurcharge", { count: 2 })}`
+        });
+      }
+    }
+    // Ammo consumption
+    if (ammoToConsumeId) {
+      const ammoItem = sheet.actor.items.get(ammoToConsumeId);
+      if (ammoItem) {
+        const currentQty = ammoItem.system.quantity ?? 1;
+        if (currentQty > 1) await ammoItem.update({ "system.quantity": currentQty - 1 });
+        else await ammoItem.delete();
+        ui.notifications.info(game.i18n.format("TRESPASSER.Notification.Combat.AmmoConsumed", { name: ammoItem.name }));
+      }
+    }
+  }
+
+  // ── 5. Item bookkeeping ────────────────────────────────────────────────────
+  if (["heavy", "mighty", "special"].includes(tier) && combatant) {
+    await combatant.setFlag("trespasser", "usedExpensiveDeed", true);
+  }
+  await item.update({ "system.uses": currentUses + 1, "system.bonusCost": currentBonusCost + costIncrease });
+
+  // ── 6. Post deed card to chat, then Start/Before phases + on-use-deed ─────
+  await postDeedCard(sheet.actor, item);
+
+  const effects      = item.system.effects || {};
+  const fragileItems = new Set();
+  const phaseOptions = { fragileItems };
+
+  await sheet._postDeedPhase("Start",  effects.start,  sheet.actor, item, phaseOptions);
+  await sheet._postDeedPhase("Before", effects.before, sheet.actor, item, phaseOptions);
+  await TrespasserEffectsHelper.triggerEffects(sheet.actor, "on-use-deed");
+
+  // ── 7. Targeted effects ────────────────────────────────────────────────────
+  for (const t of targets) {
+    if (t?.actor) {
+      await TrespasserEffectsHelper.triggerEffects(t.actor, "targeted");
+      await TrespasserEffectsHelper.triggerEffects(t.actor, "on-targeted-deed");
+    }
+  }
+
+  // ── 8. Roll (dispatch to actor-type specific handler) ─────────────────────
+  let anyHit = false, maxSparks = 0, results = [];
+
+  if (isCreature) {
+    ({ anyHit, maxSparks, results } = await rollCreatureDeed(item, sheet, targets, apBonus));
+  } else {
+    ({ anyHit, maxSparks, results } = await rollCharacterDeed(item, sheet, targets, apBonus, totalCost, userModifier));
+  }
+
+  // ── 9. Hit/miss effects ────────────────────────────────────────────────────
+  for (const t of targets) {
+    if (!t?.actor) continue;
+    if (anyHit) {
+      await TrespasserEffectsHelper.triggerEffects(t.actor,       "on-deed-hit-received");
+      await TrespasserEffectsHelper.triggerEffects(sheet.actor,   "on-deed-hit");
+    } else {
+      await TrespasserEffectsHelper.triggerEffects(t.actor,       "on-deed-miss-received");
+      await TrespasserEffectsHelper.triggerEffects(sheet.actor,   "on-deed-miss");
+    }
+  }
+
+  // ── 9b. Focus refund on total miss (heavy/mighty attack deeds) ────────
+  if (!anyHit && isAttack && totalCost > 0) {
+    const refund = Math.floor(totalCost / 2);
+    if (refund > 0) {
+      const currentFocus = sheet.actor.system.combat.focus || 0;
+      await sheet.actor.update({ "system.combat.focus": currentFocus + refund });
+      await ChatMessage.create({
+        speaker: ChatMessage.getSpeaker({ actor: sheet.actor }),
+        content: `<div class="trespasser-chat-card"><p><strong>${sheet.actor.name}</strong> ${game.i18n.format("TRESPASSER.Chat.Action.FocusRefund", { count: refund })}</p></div>`
+      });
+    }
+  }
+
+  // ── 9c. Spark selection dialog ────────────────────────────────────────────
+  let sparkChoices = null;
+  if (maxSparks > 0 && anyHit) {
+    sparkChoices = await askSparkDialog(results);
+    // null = cancelled or no sparks; proceed without spark effects
+  }
+
+  // ── 10. Spend AP + record action ──────────────────────────────────────────
+  if (combatant) {
+    const currentAP = combatant.getFlag("trespasser", "actionPoints") ?? 0;
+    await combatant.setFlag("trespasser", "actionPoints", Math.max(0, currentAP - apSpent));
+    await TrespasserCombat.recordHUDAction(sheet.actor, "attempt-deed");
+  }
+
+  // ── 11. Base/Hit/Spark/After/End phases + depletion ──────────────────────
+  const commonOptions = { ...phaseOptions, anyHit, maxSparks, results, sparkChoices };
+
+  // Base always fires (miss AND hit) for attack deeds, and applies to all
+  // targets: on a miss "you only confer the deed's Base effect" (Combat,
+  // Misses & Base Effect), so the card records every target, not just hits.
+  await sheet._postDeedPhase("Base", effects.base, sheet.actor, item, {
+    ...commonOptions, targetIds: results.map(r => r.tokenId).filter(Boolean)
+  });
+
+  // Hit and Spark only on success (or for support deeds / no targets)
+  if (anyHit || !isAttack || targets.length === 0) {
+    await sheet._postDeedPhase("Hit",  effects.hit,  sheet.actor, item, {
+      ...commonOptions, targetIds: results.filter(r => r.isHit).map(r => r.tokenId)
+    });
+
+    // Spark phase: only fire if deed spark was chosen, or if no dialog was shown
+    const showSpark = maxSparks > 0 && (!sparkChoices || sparkChoices.applyDeedSpark);
+    if (showSpark) {
+      const sparkTargets = results.filter(r => r.sparks > 0);
+      await sheet._postDeedPhase("Spark", effects.spark, sheet.actor, item, {
+        ...commonOptions,
+        title: maxSparks > 1 ? `Spark (x${maxSparks})` : "Spark",
+        targetIds: sparkTargets.map(r => r.tokenId)
+      });
+    }
+  }
+
+  await sheet._postDeedPhase("After", effects.after, sheet.actor, item, commonOptions);
+  await sheet._postDeedPhase("End",   effects.end,   sheet.actor, item, commonOptions);
+
+  // ── 11b. Separate Power bonus damage roll ────────────────────────────────
+  const powerDice = sparkChoices?.powerBonusDice ?? 0;
+  if (powerDice > 0 && anyHit) {
+    const sd = sheet.actor.system.skill_die || "d6";
+    const powerFormula = `${powerDice}${sd}`;
+    const powerRoll = new foundry.dice.Roll(powerFormula);
+    await powerRoll.evaluate();
+
+    // Determine targets for the Apply Damage button (only hit targets)
+    const hitTargetIds = results.filter(r => r.isHit).map(r => r.tokenId).filter(Boolean);
+    const targetIdAttr = hitTargetIds.length
+      ? ` data-target-ids="${hitTargetIds.join(",")}"`
+      : "";
+
+    const powerFlavor = `<div class="trespasser-chat-card">
+      <h3>${item.name} — ${game.i18n.localize("TRESPASSER.Chat.Combat.PowerBonus")}</h3>
+      <p><em>${game.i18n.format("TRESPASSER.Chat.Combat.PowerBonusDesc", { count: powerDice, die: sd })}</em></p>
+      <div class="trp-damage-actions" data-damage="${powerRoll.total}"${targetIdAttr} style="display:flex;gap:6px;margin-top:8px;">
+        <button class="apply-damage-btn" data-damage="${powerRoll.total}"${targetIdAttr} style="flex:1;background:var(--trp-bg-dark);border:1px solid #c0392b;color:#e74c3c;border-radius:4px;padding:3px 6px;cursor:pointer;font-size:var(--fs-11);">
+          <i class="fas fa-heart-broken"></i> ${game.i18n.localize("TRESPASSER.Chat.Common.ApplyDamage")}
+        </button>
+        <button class="heal-damage-btn" data-damage="${powerRoll.total}"${targetIdAttr} style="flex:1;background:var(--trp-bg-dark);border:1px solid #27ae60;color:#2ecc71;border-radius:4px;padding:3px 6px;cursor:pointer;font-size:var(--fs-11);">
+          <i class="fas fa-heart"></i> ${game.i18n.localize("TRESPASSER.Chat.Common.Heal")}
+        </button>
+      </div>
+    </div>`;
+
+    const hideCreatureRolls = game.settings.get("trespasser", "hideCreatureDamageRolls");
+    const visibility = messageVisibility((sheet.actor.type === "creature" && hideCreatureRolls) ? "gm" : "public");
+    await powerRoll.toMessage({
+      speaker: ChatMessage.getSpeaker({ actor: sheet.actor }),
+      flavor: powerFlavor
+    }, visibility);
+  }
+
+  // ── 11c. Potency bonus chat message ──────────────────────────────────────
+  const potencyBonus = sparkChoices?.potencyBonus ?? 0;
+  if (potencyBonus > 0 && anyHit) {
+    await ChatMessage.create({
+      speaker: ChatMessage.getSpeaker({ actor: sheet.actor }),
+      content: `<div class="trespasser-chat-card">
+        <h3>${item.name} — ${game.i18n.localize("TRESPASSER.Chat.Combat.PotencyBonus")}</h3>
+        <p>${game.i18n.format("TRESPASSER.Chat.Combat.PotencyBonusDesc", { count: potencyBonus })}</p>
+      </div>`
+    });
+  }
+
+  // ── 11d. Impact bonus chat message ───────────────────────────────────────
+  const impactBonus = sparkChoices?.impactBonus ?? 0;
+  if (impactBonus > 0 && anyHit) {
+    await ChatMessage.create({
+      speaker: ChatMessage.getSpeaker({ actor: sheet.actor }),
+      content: `<div class="trespasser-chat-card">
+        <h3>${item.name} — ${game.i18n.localize("TRESPASSER.Chat.Combat.ImpactBonus")}</h3>
+        <p>${game.i18n.format("TRESPASSER.Chat.Combat.ImpactBonusDesc", { count: impactBonus })}</p>
+      </div>`
+    });
+  }
+
+  if (!isCreature) {
+    for (const weapon of fragileItems) await sheet._runDepletionCheck(weapon);
+  }
+
+  // ── 12. Cleanup AOE template (unless aura, which persists) ──────────────
+  if (templateDoc && deed.targetType !== "aura") {
+    await templateDoc.delete();
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Character → Creature deed roll
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * @param {Item}   item
+ * @param {ActorSheet} sheet
+ * @param {Token[]} targets
+ * @param {number} apBonus
+ * @param {number} totalFocusCost  - for display only
+ * @param {number} userModifier
+ * @returns {{ anyHit: boolean, maxSparks: number, results: Array }}
+ */
+async function rollCharacterDeed(item, sheet, targets, apBonus, totalFocusCost = 0, userModifier = 0) {
+  const isAttack    = item.system.actionType !== "support";
+  const isAdv       = TrespasserEffectsHelper.hasAdvantage(sheet.actor, "accuracy");
+  const effectBonus   = TrespasserEffectsHelper.getAttributeBonus(sheet.actor, "accuracy", "use");
+  const totalAccuracy = sheet.actor.system.combat.accuracy ?? 0;
+  const baseAccuracy  = totalAccuracy - effectBonus;
+  const totalBonuses = `${baseAccuracy} + ${effectBonus} + ${apBonus} + ${userModifier}`;
+
+  // Engagement penalty: -2 accuracy for missile/spell deeds when engaged and not targeting adjacent
+  let engagementPenalty = 0;
+  if (isAttack && ["missile", "spell"].includes(item.system.type)) {
+    // Find the correct source token on the canvas
+    const sourceToken = sheet.actor.token?.object || 
+                       canvas.tokens.controlled.find(t => t.actor?.id === sheet.actor.id) ||
+                       canvas.tokens.placeables.find(t => t.actor?.id === sheet.actor.id);
+    if (TargetingHelper.isEngaged(sourceToken) &&
+        !TargetingHelper.isExemptFromEngagement(item.system, targets, sourceToken)) {
+      engagementPenalty = -2;
+    }
+  }
+
+  let formula = isAdv ? `2d20kh + ${totalBonuses}` : `1d20 + ${totalBonuses}`;
+  if (engagementPenalty !== 0) formula += ` + ${engagementPenalty}`;
+
+  const accRoll  = new foundry.dice.Roll(formula);
+  await accRoll.evaluate();
+  const rollTotal  = accRoll.total;
+  const diceResult = accRoll.dice[0].results[0].result;
+
+  // Trigger accuracy "use" effects
+  await TrespasserEffectsHelper.triggerEffects(sheet.actor, "use", { filterTarget: "accuracy" });
+
+  let anyHit = false, maxSparks = 0, resultsHtml = "";
+  const results = [];
+
+  const targetList = isAttack ? targets : [null]; // support: always one pseudo-result vs CD 10
+
+  for (const targetToken of targetList) {
+    const targetActor = targetToken?.actor ?? null;
+
+    // Determine Defense Class (DC)
+    let dc = 10; // Default 10
+    if (isAttack && targetActor) {
+      const statKey  = item.system.accuracyTest?.toLowerCase() || "guard";
+      const totalDef = targetActor.system.combat[statKey] ?? 10;
+      const effBonus = TrespasserEffectsHelper.getAttributeBonus(targetActor, statKey, "use");
+      const targetCD = totalDef + effBonus;
+      // Characters aggregate bonuses in combat.stat, creatures keep them separate.
+      dc = (targetActor.type === "character") ? (targetCD + 10) : targetCD;
+    }
+
+    let isHit = rollTotal >= dc;
+    if (diceResult === 20) isHit = true; // Nat 20 auto-success
+    if (isHit) anyHit = true;
+
+    const diff    = rollTotal - dc;
+    let sparks = 0, shadows = 0;
+    if (diff >= 0) sparks  = Math.floor(diff / 5);
+    else           shadows = Math.floor(Math.abs(diff) / 5);
+    if (diceResult === 20) sparks  += 1;
+    if (diceResult === 1)  shadows += 1;
+    // Sparks cancel Shadows
+    const net = sparks - shadows;
+    sparks  = Math.max(0, net);
+    shadows = Math.max(0, -net);
+
+    if (sparks > maxSparks) maxSparks = sparks;
+
+    // Track per-target results
+    results.push({
+      tokenId: targetToken?.id ?? null,
+      tokenName: targetToken?.name ?? null,
+      actorId: targetActor?.id ?? null,
+      isHit,
+      sparks,
+      shadows,
+      dc
+    });
+
+    if (targetToken) {
+      // Always show target info (name, CD, hit/miss, sparks/shadows) for every target
+      resultsHtml += `
+        <div class="target-result" style="border-top:1px solid var(--trp-border-light);padding-top:5px;margin-top:5px;">
+          <div style="display:flex;justify-content:space-between;align-items:center;">
+            <strong>${targetToken.name} <span style="font-size:var(--fs-10);color:var(--trp-text-dim);">(${game.i18n.localize("TRESPASSER.Sheet.Combat." + (item.system.accuracyTest || "Guard"))}: ${dc})</span></strong>
+            <span class="${isHit ? "hit-text" : "miss-text"}" style="font-weight:bold;">${isHit ? game.i18n.localize("TRESPASSER.Chat.Combat.Hit") : game.i18n.localize("TRESPASSER.Chat.Combat.Miss")}</span>
+          </div>
+          <div style="display:flex;gap:10px;font-size:var(--fs-11);">
+            <span style="color:var(--trp-spark);">${game.i18n.format("TRESPASSER.Chat.Combat.Sparks",  { count: sparks  })}</span>
+            <span style="color:var(--trp-shadow);">${game.i18n.format("TRESPASSER.Chat.Combat.Shadows", { count: shadows })}</span>
+          </div>
+        </div>`;
+    } else {
+      // Support deed (no target)
+      resultsHtml += `
+        <div class="incantation-metrics" style="display:flex;gap:10px;margin:10px 0;font-weight:bold;">
+          <div style="color:var(--trp-spark);"><i class="fas fa-sun"></i>  ${game.i18n.format("TRESPASSER.Chat.Combat.Sparks",  { count: sparks  })}</div>
+          <div style="color:var(--trp-shadow);"><i class="fas fa-moon"></i> ${game.i18n.format("TRESPASSER.Chat.Combat.Shadows", { count: shadows })}</div>
+        </div>`;
+    }
+  }
+
+  let flavor = `<div class="trespasser-chat-card">
+    <h3>${game.i18n.format("TRESPASSER.Chat.Combat.AccuracyRoll", { name: item.name })}${isAdv ? " (Adv)" : ""}</h3>
+    <p><strong>${game.i18n.localize("TRESPASSER.Chat.Common.RollTotal")}</strong> ${rollTotal} <span style="font-size:var(--fs-10);color:var(--trp-text-dim);">(d20: ${diceResult})</span></p>
+    ${resultsHtml}`;
+  if (totalFocusCost > 0) flavor += `<p class="cost-note" style="margin-top:5px;">${game.i18n.format("TRESPASSER.Chat.Action.SpentFocus", { count: totalFocusCost })}</p>`;
+  if (apBonus > 0)        flavor += `<p class="cost-note" style="margin-top:2px;color:#2ecc71;">+${apBonus} ${game.i18n.localize("TRESPASSER.Chat.Check.AccuracyFromAP")}</p>`;
+  if (engagementPenalty !== 0) flavor += `<p class="cost-note" style="margin-top:2px;color:#e74c3c;">${game.i18n.localize("TRESPASSER.Chat.Combat.EngagementPenalty")}</p>`;
+  flavor += `</div>`;
+
+  await accRoll.toMessage({ speaker: ChatMessage.getSpeaker({ actor: sheet.actor }), flavor });
+
+  return { anyHit, maxSparks, results };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Creature → Character deed roll (defense roll mechanic)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * @param {Item}   item
+ * @param {ActorSheet} sheet
+ * @param {Token[]} targets
+ * @param {number} apBonus
+ * @returns {{ anyHit: boolean, maxSparks: number, results: Array }}
+ */
+async function rollCreatureDeed(item, sheet, targets, apBonus) {
+  const isAttack = item.system.actionType !== "support";
+
+  // Support deeds: just post phases, no roll
+  if (!isAttack) {
+    return { anyHit: true, maxSparks: 0, results: [] };
+  }
+
+  // Creature's accuracy DC
+  const creatureEffBonus = TrespasserEffectsHelper.getAttributeBonus(sheet.actor, "accuracy", "use");
+  const creatureAccuracy = sheet.actor.system.combat.accuracy ?? 0;
+  const creatureDC       = creatureAccuracy + creatureEffBonus + apBonus;
+
+  let anyHit = false, maxSparks = 0;
+  const results = [];
+
+  await TrespasserEffectsHelper.triggerEffects(sheet.actor, "use", { filterTarget: "accuracy" });
+
+  const targetPromises = targets.map(async (targetToken) => {
+    const targetActor = targetToken?.actor ?? null;
+    if (!targetActor) return null;
+
+    const statKey     = item.system.accuracyTest?.toLowerCase() || "guard";
+    const totalDef    = targetActor.system.combat[statKey] ?? 10;
+    const defEffBonus = TrespasserEffectsHelper.getAttributeBonus(targetActor, statKey, "use");
+    
+    let defTotal, diceResult = null, finalDC = creatureDC, isHit;
+    const label = statKey.charAt(0).toUpperCase() + statKey.slice(1);
+
+    if (targetActor.type === "creature") {
+      // NPC vs NPC: No rolls, just compare values
+      defTotal = totalDef + defEffBonus;
+      isHit    = finalDC >= defTotal;
+    } else {
+      // Character: prompt the OWNING PLAYER to roll defense via socket/flag
+      const defenseResult = await requestPlayerDefenseRoll({
+        targetActorId: targetActor.id,
+        targetTokenId: targetToken.id,
+        statKey,
+        creatureDC,
+        deedName: item.name,
+        creatureName: sheet.actor.name
+      });
+
+      if (!defenseResult) return null; // Player cancelled or timed out
+
+      defTotal = defenseResult.total;
+      diceResult = defenseResult.diceResult;
+      finalDC = defenseResult.cd;
+      isHit = finalDC >= defTotal;
+    }
+
+    const diff = finalDC - defTotal;
+    let sparks = 0, shadows = 0;
+    if (isHit) {
+      sparks  = Math.floor(diff / 5);
+      if (diceResult === 1)  sparks  += 1; 
+    } else {
+      shadows = Math.floor(Math.abs(diff) / 5);
+      if (diceResult === 20) shadows += 1;
+    }
+    // Sparks cancel Shadows
+    const net = sparks - shadows;
+    sparks  = Math.max(0, net);
+    shadows = Math.max(0, -net);
+
+    const resultObj = {
+      tokenId: targetToken.id,
+      tokenName: targetToken.name,
+      actorId: targetActor.id,
+      isHit,
+      sparks,
+      shadows,
+      dc: finalDC
+    };
+
+    const resultsHtml = `
+      <div class="target-result" style="border-top:1px solid var(--trp-border-light);padding-top:5px;margin-top:5px;">
+        <div style="display:flex;justify-content:space-between;align-items:center;">
+          <strong>${targetToken.name} <span style="font-size:var(--fs-10);color:var(--trp-text-dim);">(${game.i18n.localize("TRESPASSER.Chat.Combat.Defense")}: ${defTotal})</span></strong>
+          <span class="${isHit ? "hit-text" : "miss-text"}" style="font-weight:bold;">${isHit ? game.i18n.localize("TRESPASSER.Chat.Combat.Hit") : game.i18n.localize("TRESPASSER.Chat.Combat.Miss")}</span>
+        </div>
+        <div style="display:flex;gap:10px;font-size:var(--fs-11);">
+          <span style="color:var(--trp-spark);">${game.i18n.format("TRESPASSER.Chat.Combat.Sparks",  { count: sparks  })}</span>
+          <span style="color:var(--trp-shadow);">${game.i18n.format("TRESPASSER.Chat.Combat.Shadows", { count: shadows })}</span>
+        </div>
+      </div>`;
+
+    // Post to chat immediately
+    let flavor = "";
+    if (targetActor.type === "creature") {
+      flavor = `<div class="trespasser-chat-card">
+        <h3>${item.name} — ${game.i18n.localize("TRESPASSER.Chat.Combat.Defense")}</h3>
+        <p><strong>${targetToken.name}</strong> ${game.i18n.localize("TRESPASSER.Chat.Combat.Defense")}: <strong>${defTotal}</strong></p>
+        <p>${game.i18n.localize("TRESPASSER.Chat.Check.CreatureAccuracy")}: <strong>${finalDC}</strong></p>
+        <p class="${isHit ? "hit-text" : "miss-text"}" style="font-weight:bold;font-size:var(--fs-14);text-align:center;">${isHit ? game.i18n.localize("TRESPASSER.Chat.Combat.Hit") : game.i18n.localize("TRESPASSER.Chat.Combat.Miss")}</p>
+        ${resultsHtml}
+      </div>`;
+    } else {
+      flavor = `<div class="trespasser-chat-card">
+        <h3>${item.name} — ${game.i18n.localize("TRESPASSER.Chat.Check.DefenseRoll")}</h3>
+        <p><strong>${targetToken.name}</strong> ${game.i18n.localize("TRESPASSER.Chat.Common.Rolls")} ${game.i18n.localize(`TRESPASSER.Sheet.Combat.${label}`)}: <strong>${defTotal}</strong> <span style="font-size:var(--fs-10);color:var(--trp-text-dim);">(d20: ${diceResult})</span></p>
+        <p>${game.i18n.localize("TRESPASSER.Chat.Check.CreatureAccuracy")}: <strong>${finalDC}</strong></p>
+        <p class="${isHit ? "hit-text" : "miss-text"}" style="font-weight:bold;font-size:var(--fs-14);text-align:center;">${isHit ? game.i18n.localize("TRESPASSER.Chat.Combat.Hit") : game.i18n.localize("TRESPASSER.Chat.Combat.Miss")}</p>
+        ${resultsHtml}
+        </div>`;
+    }
+    
+    await ChatMessage.create({
+      speaker: ChatMessage.getSpeaker({ actor: sheet.actor }),
+      content: flavor
+    });
+
+    // Counter reaction: if creature missed, defender may counter-attack
+    if (!isHit && shadows > 0) {
+      const creatureToken = canvas.tokens.placeables.find(t => t.actor?.id === sheet.actor.id);
+      const { canCounter, weapon } = TargetingHelper.checkCounterEligibility(targetToken, creatureToken);
+
+      if (canCounter && targetActor.type === "character") {
+        // Floating promise so it doesn't block the Promise.all resolution for other targets
+        _askCounterReaction(targetToken, creatureToken, weapon, shadows).then(async (counterAccepted) => {
+          if (counterAccepted) {
+            // Roll counter damage: shadows × weapon die
+            const wDie = weapon.system.weaponDie || "d4";
+            const counterFormula = `${shadows}${wDie}`;
+            const counterRoll = new foundry.dice.Roll(counterFormula);
+            await counterRoll.evaluate();
+
+            const counterFlavor = `<div class="trespasser-chat-card">
+              <h3>${game.i18n.format("TRESPASSER.Chat.Combat.CounterReaction", { name: targetToken.name })}</h3>
+              <p>${game.i18n.format("TRESPASSER.Chat.Combat.CounterDamageDesc", { count: shadows, die: wDie, weapon: weapon.name })}</p>
+              <div class="trp-damage-actions" data-damage="${counterRoll.total}" data-target-ids="${creatureToken?.id ?? ""}" style="display:flex;gap:6px;margin-top:8px;">
+                <button class="apply-damage-btn" data-damage="${counterRoll.total}" data-target-ids="${creatureToken?.id ?? ""}" style="flex:1;background:var(--trp-bg-dark);border:1px solid #c0392b;color:#e74c3c;border-radius:4px;padding:3px 6px;cursor:pointer;font-size:var(--fs-11);">
+                  <i class="fas fa-heart-broken"></i> ${game.i18n.localize("TRESPASSER.Chat.Common.ApplyDamage")}
+                </button>
+              </div>
+            </div>`;
+            await counterRoll.toMessage({
+              speaker: ChatMessage.getSpeaker({ actor: targetActor }),
+              flavor: counterFlavor
+            });
+          }
+        });
+      }
+    }
+
+    return resultObj;
+  });
+
+  const resolvedResults = await Promise.all(targetPromises);
+
+  for (const res of resolvedResults) {
+    if (!res) continue;
+    results.push(res);
+    if (res.isHit) anyHit = true;
+    if (res.sparks > maxSparks) maxSparks = res.sparks;
+  }
+
+  return { anyHit, maxSparks, results };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Counter reaction prompt
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Prompt the defender to use their counter reaction.
+ * @param {Token} defenderToken
+ * @param {Token} creatureToken
+ * @param {Item} weapon  The defender's melee weapon
+ * @param {number} shadows  Number of shadows (= counter dice)
+ * @returns {Promise<boolean>}
+ */
+async function _askCounterReaction(defenderToken, creatureToken, weapon, shadows) {
+  const wDie = weapon.system.weaponDie || "d4";
+  const content = `<div class="trespasser-dialog">
+    <p>${game.i18n.format("TRESPASSER.Chat.Combat.CounterPrompt", {
+      defender: defenderToken.name,
+      count: shadows,
+      die: wDie,
+      weapon: weapon.name,
+      creature: creatureToken?.name ?? "?"
+    })}</p>
+  </div>`;
+
+  const result = await foundry.applications.api.DialogV2.wait({
+    window: { title: game.i18n.localize("TRESPASSER.Chat.Combat.CounterReaction") },
+    classes: ["trespasser", "dialog"],
+    position: { width: 380 },
+    content,
+    buttons: [
+      {
+        action: "counter",
+        icon: "fas fa-shield-alt",
+        label: game.i18n.localize("TRESPASSER.Global.Action.Accept"),
+        default: true,
+        callback: () => true
+      },
+      {
+        action: "pass",
+        icon: "fas fa-times",
+        label: game.i18n.localize("TRESPASSER.Global.Action.Pass"),
+        callback: () => false
+      }
+    ],
+    rejectClose: false,
+    close: () => false
+  });
+
+  return result;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Deed phase chat output
+// ─────────────────────────────────────────────────────────────────────────────
+
+export async function postDeedPhase(phaseName, phaseData, actor, item, options, sheet) {
+  const pData = phaseData || {};
+  let finalEffects = [];
+  
+  if (pData.appliedEffects) finalEffects = Array.from(pData.appliedEffects).map(e => ({...e}));
+
+  const activeWeapons = sheet._getActiveWeapons();
+
+  const validWeaponDeedTypes = ["melee", "missile", "versatile", "innate"];
+  const isWeaponDeed = validWeaponDeedTypes.includes(item?.system?.type);
+
+  if (pData.appliesWeaponEffects || (pData.damage && pData.damage.includes("<wd>")) || isWeaponDeed) {
+    for (const weapon of activeWeapons) {
+      if (!weapon) continue;
+      
+      // Weapon Basic Effects
+      if (pData.appliesWeaponEffects && weapon.system.effects) {
+        finalEffects.push(...Array.from(weapon.system.effects).map(e => ({...e})));
+      }
+
+      // Enhancement Effects: ONLY on the Spark phase
+      if (phaseName === "Spark" && Array.isArray(weapon.system.enhancementEffects)) {
+        finalEffects.push(...Array.from(weapon.system.enhancementEffects).map(e => ({...e})));
+      }
+
+      // Oil Effects: ONLY on the Hit phase
+      if (phaseName === "Hit" && options.anyHit && Array.isArray(weapon.system.oilEffects) && weapon.system.oilEffects.length > 0) {
+        finalEffects.push(...Array.from(weapon.system.oilEffects).map(e => ({...e})));
+        // Consume the oil effects after applying them to the Hit phase
+        weapon.update({ "system.oilEffects": [] });
+      }
+
+      if (weapon.system.properties?.fragile && options.fragileItems) options.fragileItems.add(weapon);
+    }
+  }
+
+  const hasDamage      = pData.damage      && pData.damage.trim()      !== "";
+  const hasDescription = pData.description && pData.description.trim() !== "";
+  const hasEffects     = finalEffects.length > 0;
+
+  if (!hasDamage && !hasEffects && !hasDescription && !options.forceOutput) return;
+
+  const effectsHtml = await TrespasserEffectsHelper.applyEffectChat(finalEffects, actor, {
+    title: options.title || phaseName,
+    description: pData.description,
+    renderOnly: true,
+    bypassFilter: true
+  });
+
+  let flavorHtml = effectsHtml || `<div class="trespasser-chat-card"><h3>${item.name} — ${options.title || phaseName}</h3>`;
+  if (!effectsHtml && hasDescription) flavorHtml += `<p><em>${pData.description}</em></p>`;
+  if (options.introText) flavorHtml += `<p>${options.introText}</p>`;
+  flavorHtml += `</div>`;
+
+  if (hasDamage) {
+    let parsedDamage = phaseData.damage;
+    const skillDie  = actor.system.skill_die || "d6";
+    let weaponDie   = "d4";
+
+    if (activeWeapons.length > 0) {
+      if (activeWeapons.length > 1) {
+        const d1Str = activeWeapons[0].system.weaponDie || "d4";
+        const d2Str = activeWeapons[1].system.weaponDie || "d4";
+        const d1 = parseInt(String(d1Str).replace("d", "")) || 0;
+        const d2 = parseInt(String(d2Str).replace("d", "")) || 0;
+        weaponDie = d1 >= d2 ? d1Str : d2Str;
+      } else {
+        weaponDie = activeWeapons[0].system.weaponDie || "0";
+      }
+    }
+
+    parsedDamage = TrespasserEffectsHelper.replacePlaceholders(parsedDamage, actor, weaponDie);
+    const damageBonus = await TrespasserEffectsHelper.evaluateDamageBonus(actor, "damage_dealt", weaponDie);
+    if (damageBonus !== 0) parsedDamage = `(${parsedDamage}) + ${damageBonus}`;
+
+    let rollObj;
+    try {
+      rollObj = new foundry.dice.Roll(parsedDamage);
+      await rollObj.evaluate();
+    } catch (e) { console.error("Trespasser | Deed Damage Roll Error", e); }
+
+    if (rollObj) {
+      const targetIdAttr = options.targetIds?.length
+        ? ` data-target-ids="${options.targetIds.join(",")}"`
+        : "";
+      const applyHealBtns = `<div class="trp-damage-actions" data-damage="${rollObj.total}"${targetIdAttr} style="display:flex;gap:6px;margin-top:8px;">
+        <button class="apply-damage-btn" data-damage="${rollObj.total}"${targetIdAttr} style="flex:1;background:var(--trp-bg-dark);border:1px solid #c0392b;color:#e74c3c;border-radius:4px;padding:3px 6px;cursor:pointer;font-size:var(--fs-11);">
+          <i class="fas fa-heart-broken"></i> ${game.i18n.localize("TRESPASSER.Chat.Common.ApplyDamage")}
+        </button>
+        <button class="heal-damage-btn" data-damage="${rollObj.total}"${targetIdAttr} style="flex:1;background:var(--trp-bg-dark);border:1px solid #27ae60;color:#2ecc71;border-radius:4px;padding:3px 6px;cursor:pointer;font-size:var(--fs-11);">
+          <i class="fas fa-heart"></i> ${game.i18n.localize("TRESPASSER.Chat.Common.Heal")}
+        </button>
+      </div>`;
+      const hideCreatureRolls = game.settings.get("trespasser", "hideCreatureDamageRolls");
+      const visibility = messageVisibility((actor.type === "creature" && hideCreatureRolls) ? "gm" : "public");
+      await rollObj.toMessage({
+        speaker: ChatMessage.getSpeaker({ actor }),
+        flavor: flavorHtml + applyHealBtns
+      }, visibility);
+      return;
+    }
+  }
+
+  await ChatMessage.create({ speaker: ChatMessage.getSpeaker({ actor }), content: flavorHtml });
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Other exports (Challenge Roll helpers used by character sheet)
+// ─────────────────────────────────────────────────────────────────────────────
+
+export async function requestCDAndRoll(roll, flavor, sheet) {
+  const content = `
+    <div class="form-group">
+      <label>${game.i18n.localize("TRESPASSER.Dialog.SkillCheck.ChallengeDifficulty")}</label>
+      <input type="number" name="roll-cd" value="10" autofocus />
+    </div>`;
+
+  const cd = await foundry.applications.api.DialogV2.wait({
+    window: { title: game.i18n.localize("TRESPASSER.Dialog.SkillCheck.ChallengeTitle") },
+    classes: ["trespasser", "dialog"],
+    content,
+    buttons: [
+      {
+        action: "roll",
+        label: game.i18n.localize("TRESPASSER.Global.Action.RunCheck"),
+        default: true,
+        callback: (event, button) => parseInt(button.form.elements["roll-cd"].value) || 0
+      },
+      {
+        action: "cancel",
+        label: game.i18n.localize("TRESPASSER.Global.Action.Cancel"),
+        callback: () => null
+      }
+    ],
+    rejectClose: false,
+    close: () => null
+  });
+
+  if (cd === null) return null;
+  return sheet._evaluateAndShowRoll(roll, flavor, cd);
+}
+
+export async function evaluateAndShowRoll(roll, flavor, cd, sheet) {
+  await roll.evaluate();
+  const total = roll.total;
+  const diff  = total - cd;
+  let sparks = 0, shadows = 0;
+
+  if (diff >= 0) sparks  = Math.floor(diff / 5);
+  else           shadows = Math.floor(Math.abs(diff) / 5);
+
+  const dieResult = roll.dice[0]?.results[0]?.result;
+  if (dieResult === 20) sparks  += 1;
+  if (dieResult === 1)  shadows += 1;
+
+  const metrics = `
+    <div class="incantation-metrics" style="display:flex;gap:10px;margin:10px 0;font-weight:bold;">
+      <div class="metric spark"  style="color:var(--trp-spark);"><i class="fas fa-sun"></i>  ${game.i18n.format("TRESPASSER.Chat.Combat.Sparks",  { count: sparks  })}</div>
+      <div class="metric shadow" style="color:var(--trp-shadow);"><i class="fas fa-moon"></i> ${game.i18n.format("TRESPASSER.Chat.Combat.Shadows", { count: shadows })}</div>
+    </div>`;
+
+  await roll.toMessage({
+    speaker: ChatMessage.getSpeaker({ actor: sheet.actor }),
+    flavor:  `${flavor}<p>${game.i18n.format("TRESPASSER.Chat.Check.VsCD", { cd })}</p>${metrics}`
+  });
+
+  return roll;
+}

--- a/module/sheets/chracter/handlers-talent.mjs
+++ b/module/sheets/chracter/handlers-talent.mjs
@@ -1,0 +1,238 @@
+/**
+ * Character Sheet — Talent, Feature, Incantation roll handlers
+ */
+
+import { TrespasserEffectsHelper } from "../../helpers/effects-helper.mjs";
+import { TrespasserCombat }        from "../../documents/combat.mjs";
+import { messageVisibility }       from "../../helpers/compat.mjs";
+
+
+export async function onTalentRoll(event, sheet) {
+  event.preventDefault();
+  event.stopImmediatePropagation();
+  const el = event.currentTarget.closest("[data-item-id]");
+  if (!el) return;
+  const item = sheet.actor.items.get(el.dataset.itemId);
+  if (!item) return;
+
+  const isUsable = item.system.usable;
+  let totalCost  = 0;
+
+  if (isUsable) {
+    const baseCost      = item.system.focusCost  || 0;
+    const currentBonusCost = item.system.bonusCost || 0;
+    const costIncrease  = item.system.focusIncrease || 0;
+    totalCost = baseCost + currentBonusCost;
+
+    const restrictAPF = game.settings.get("trespasser", "restrictAPFocusUsage");
+    const isAction    = item.system.type === "action";
+    const combatant   = TrespasserCombat.getPhaseCombatant(sheet.actor);
+
+    let availableAP = 0;
+    let currentFocus = 0;
+
+    // 1. AP check
+    if (isAction && combatant) {
+      availableAP = combatant.getFlag("trespasser", "actionPoints") ?? 0;
+      if (restrictAPF && availableAP < 1) {
+        ui.notifications.warn(game.i18n.localize("TRESPASSER.Notification.Combat.NotEnoughAP"));
+        return;
+      }
+    }
+
+    // 2. Focus check
+    if (totalCost > 0) {
+      currentFocus = sheet.actor.system.combat.focus || 0;
+      if (currentFocus < totalCost && restrictAPF) {
+        ui.notifications.error(game.i18n.format("TRESPASSER.Notification.Combat.NotEnoughFocus", { name: item.name, cost: totalCost, current: currentFocus }));
+        return;
+      }
+    }
+
+    await combatant.setFlag("trespasser", "actionPoints", Math.max(0, availableAP - 1));
+    await sheet.actor.update({ "system.combat.focus": Math.max(0, currentFocus - totalCost) });
+
+
+    await item.update({
+      "system.uses":      (item.system.uses || 0) + 1,
+      "system.bonusCost": currentBonusCost + costIncrease
+    });
+  }
+
+  const enrichedDescription = await foundry.applications.ux.TextEditor.implementation.enrichHTML(item.system.description, {
+    async: true, secrets: item.isOwner, relativeTo: item
+  });
+
+  let cardHtml = `<div class="trespasser-chat-card talent-card">
+    <h3>Talent: ${item.name}</h3>
+    ${totalCost > 0 ? `<p class="cost-note">${game.i18n.format("TRESPASSER.Chat.Action.SpentFocus", { count: totalCost })}</p>` : ""}
+    <details>
+      <summary style="cursor:pointer;color:var(--trp-gold-bright);font-family:var(--trp-font-header);font-size:var(--fs-11);margin-bottom:5px;">
+        <i class="fas fa-info-circle"></i> ${game.i18n.localize("TRESPASSER.Chat.Common.DescriptionExpand")}
+      </summary>
+        <div class="collapsible-content" style="background:var(--trp-bg-overlay);padding:8px;border-radius:4px;border:1px solid var(--trp-border);margin-bottom:10px;font-size:var(--fs-12);">
+        ${enrichedDescription}
+      </div>
+    </details>`;
+
+  if (item.system.effects?.length > 0) {
+    cardHtml += `<div class="applied-effects"><strong>${game.i18n.localize("TRESPASSER.Chat.Common.EffectsStates")}</strong>`;
+    for (const eff of item.system.effects) {
+      cardHtml += `<a class="apply-effect-btn" data-uuid="${eff.uuid}" data-intensity="${eff.intensity || 0}">
+        <img src="${eff.img}" width="20" height="20" /><span>${eff.name}</span><i class="fas fa-hand-sparkles"></i>
+      </a>`;
+    }
+    cardHtml += `</div>`;
+  }
+  cardHtml += `</div>`;
+
+  let formula = isUsable ? (item.system.rollDice || "") : "";
+  if (formula.trim() !== "") {
+    let weaponDie = "d4";
+    const mainHandId = sheet.actor.system.equipment?.main_hand;
+    if (mainHandId) {
+      const weapon = sheet.actor.items.get(mainHandId);
+      if (weapon?.system.weaponDie) weaponDie = weapon.system.weaponDie;
+    }
+
+    formula = TrespasserEffectsHelper.replacePlaceholders(formula, sheet.actor, weaponDie);
+
+    const roll = new foundry.dice.Roll(formula);
+    await roll.evaluate();
+
+    const applyHealBtns = `<div class="trp-damage-actions" style="display:flex;gap:6px;margin-top:8px;">
+      <button class="apply-damage-btn" data-damage="${roll.total}" style="flex:1;background:var(--trp-bg-dark);border:1px solid var(--trp-red-dim);color:var(--trp-red);border-radius:4px;padding:3px 6px;cursor:pointer;font-size:var(--fs-11);">
+        <i class="fas fa-heart-broken"></i> Apply Damage
+      </button>
+      <button class="heal-damage-btn" data-damage="${roll.total}" style="flex:1;background:var(--trp-bg-dark);border:1px solid var(--trp-green);color:var(--trp-green-bright);border-radius:4px;padding:3px 6px;cursor:pointer;font-size:var(--fs-11);">
+        <i class="fas fa-heart"></i> Heal
+      </button>
+    </div>`;
+
+    const hideCreatureRolls = game.settings.get("trespasser", "hideCreatureDamageRolls");
+    const visibility = messageVisibility((sheet.actor.type === "creature" && hideCreatureRolls) ? "gm" : "public");
+    await roll.toMessage({ speaker: ChatMessage.getSpeaker({ actor: sheet.actor }), flavor: cardHtml + applyHealBtns }, visibility);
+
+    if (item.system.rollDice?.includes("<wd>")) {
+      if (mainHandId) {
+        const weapon = sheet.actor.items.get(mainHandId);
+        if (weapon?.system.properties?.fragile) await sheet._runDepletionCheck(weapon);
+      }
+    }
+  } else {
+    await foundry.documents.BaseChatMessage.create({
+      speaker: ChatMessage.getSpeaker({ actor: sheet.actor }), content: cardHtml
+    });
+  }
+}
+
+export async function onFeatureRoll(event, sheet) {
+  event.preventDefault();
+  event.stopImmediatePropagation();
+  const li   = event.currentTarget.closest("[data-item-id]");
+  const item = sheet.actor.items.get(li.dataset.itemId);
+  if (!item) return;
+
+  const combatant   = TrespasserCombat.getPhaseCombatant(sheet.actor);
+  const restrictAPF = game.settings.get("trespasser", "restrictAPFocusUsage");
+  const isAction    = item.system.type === "action";
+
+  // 1. AP check and deduction
+  if (isAction && combatant) {
+    const availableAP = combatant.getFlag("trespasser", "actionPoints") ?? 0;
+    if (restrictAPF && availableAP < 1) {
+      ui.notifications.warn(game.i18n.localize("TRESPASSER.Notification.Combat.NotEnoughAP"));
+      return;
+    }
+    await combatant.setFlag("trespasser", "actionPoints", Math.max(0, availableAP - 1));
+  }
+
+  const enrichedRef = await foundry.applications.ux.TextEditor.implementation.enrichHTML(item.system.description, {
+    async: true, secrets: item.isOwner, relativeTo: item
+  });
+
+  const content = `
+    <div class="trespasser-chat-card feature-card">
+      <h3>Feature: ${item.name}</h3>
+      <details>
+        <summary style="cursor:pointer;color:var(--trp-gold-bright);font-family:var(--trp-font-header);font-size:var(--fs-11);margin-bottom:5px;">
+          <i class="fas fa-info-circle"></i> ${game.i18n.localize("TRESPASSER.Chat.Common.DescriptionExpand")}
+        </summary>
+          <div class="collapsible-content" style="background:var(--trp-bg-overlay);padding:8px;border-radius:4px;border:1px solid var(--trp-border);margin-bottom:10px;font-size:var(--fs-12);">
+          ${enrichedRef}
+        </div>
+      </details>
+    </div>`;
+
+  await ChatMessage.create({ speaker: ChatMessage.getSpeaker({ actor: sheet.actor }), content });
+}
+
+export async function onIncantationRoll(event, sheet) {
+  event.preventDefault();
+  event.stopImmediatePropagation();
+  const el = event.currentTarget.closest("[data-item-id]");
+  if (!el) return;
+  const item = sheet.actor.items.get(el.dataset.itemId);
+  if (!item) return;
+
+  const cost             = item.system.enduranceCost || 0;
+  const currentEndurance = sheet.actor.system.endurance || 0;
+
+  if (currentEndurance < cost) {
+    ui.notifications.error(game.i18n.format("TRESPASSER.Notification.Combat.NotEnoughEndurance", { name: item.name, cost: cost, current: currentEndurance }));
+    return;
+  }
+
+  await sheet.actor.update({ "system.endurance": currentEndurance - cost });
+
+  const keyAttr   = sheet.actor.system.key_attribute || "mighty";
+  const attrValue = sheet.actor.system.attributes[keyAttr] ?? 0;
+  const hasMagic  = sheet.actor.system.skills?.magic || false;
+  const skillBonus = sheet.actor.system.skill || 0;
+
+  let formula = `1d20 + ${attrValue}`;
+  if (hasMagic) formula += ` + ${skillBonus}`;
+
+  const roll = new foundry.dice.Roll(formula);
+  await roll.evaluate();
+
+  const target    = 15;
+  const diff      = roll.total - target;
+  const isSuccess = roll.total >= target;
+  let sparks = 0, shadows = 0;
+
+  if (diff >= 0) sparks  = Math.floor(diff / 5);
+  else           shadows = Math.floor(Math.abs(diff) / 5);
+
+  const diceResult = roll.dice[0].results[0].result;
+  if (diceResult === 20) sparks  += 1;
+  if (diceResult === 1)  shadows += 1;
+
+  const enrichedDescription = await foundry.applications.ux.TextEditor.implementation.enrichHTML(item.system.description, {
+    async: true, secrets: item.isOwner, relativeTo: item
+  });
+
+  const resultText = isSuccess
+    ? `<span class="hit-text"  style="font-weight:bold;color:var(--trp-green-bright);">${game.i18n.localize("TRESPASSER.Chat.Common.Success")}</span>`
+    : `<span class="miss-text" style="font-weight:bold;color:var(--trp-red);">${game.i18n.localize("TRESPASSER.Chat.Common.Failure")}</span>`;
+
+  const flavor = `
+    <div class="trespasser-chat-card incantation-card">
+      <h3>Incantation: ${item.name}</h3>
+      <p>${game.i18n.format("TRESPASSER.Chat.Check.ResultVs", { total: roll.total, target: target, status: resultText })}</p>
+      <div class="incantation-metrics" style="display:flex;gap:10px;margin:10px 0;font-weight:bold;">
+        <div class="metric spark"  style="color:var(--trp-cyan);"><i class="fas fa-sun"></i>  ${game.i18n.format("TRESPASSER.Chat.Combat.Sparks",  { count: sparks  })}</div>
+        <div class="metric shadow" style="color:var(--trp-purple);"><i class="fas fa-moon"></i> ${game.i18n.format("TRESPASSER.Chat.Combat.Shadows", { count: shadows })}</div>
+      </div>
+      <details>
+        <summary style="cursor:pointer;color:var(--trp-gold-bright);font-family:var(--trp-font-header);font-size:var(--fs-11);margin-bottom:5px;">
+          <i class="fas fa-info-circle"></i> ${game.i18n.localize("TRESPASSER.Chat.Common.DescriptionExpand")}
+        </summary>
+          <div class="collapsible-content" style="background:var(--trp-bg-overlay);padding:8px;border-radius:4px;border:1px solid var(--trp-border);margin-bottom:10px;font-size:var(--fs-12);">
+          ${enrichedDescription}
+        </div>
+      </details>
+    </div>`;
+
+  await roll.toMessage({ speaker: ChatMessage.getSpeaker({ actor: sheet.actor }), flavor });
+}

--- a/module/sheets/event-clock-sheet.mjs
+++ b/module/sheets/event-clock-sheet.mjs
@@ -64,7 +64,7 @@ export class EventClockSheet extends api.HandlebarsApplicationMixin(api.Applicat
     context.clockFilled = filled;
 
     // Enrich description HTML
-    context.descriptionHTML = await TextEditor.enrichHTML(clock.description || "", {
+    context.descriptionHTML = await foundry.applications.ux.TextEditor.implementation.enrichHTML(clock.description || "", {
         async: true,
         secrets: true
     });

--- a/module/sheets/item-accessory-sheet.mjs
+++ b/module/sheets/item-accessory-sheet.mjs
@@ -98,7 +98,7 @@ export class TrespasserAccessorySheet extends api.HandlebarsApplicationMixin(she
 
   async _onDropItem(event) {
     event.preventDefault();
-    const data = TextEditor.getDragEventData(event);
+    const data = foundry.applications.ux.TextEditor.implementation.getDragEventData(event);
     if (!data || data.type !== "Item") return;
     
     const targetEl = event.currentTarget;

--- a/module/sheets/item-armor-sheet.mjs
+++ b/module/sheets/item-armor-sheet.mjs
@@ -101,7 +101,7 @@ export class TrespasserArmorSheet extends api.HandlebarsApplicationMixin(sheets.
 
   async _onDropItem(event) {
     event.preventDefault();
-    const data = TextEditor.getDragEventData(event);
+    const data = foundry.applications.ux.TextEditor.implementation.getDragEventData(event);
     if (!data || data.type !== "Item") return;
     
     const targetEl = event.currentTarget;

--- a/module/sheets/item-build-sheet.mjs
+++ b/module/sheets/item-build-sheet.mjs
@@ -141,7 +141,7 @@ export class TrespasserBuildSheet extends api.HandlebarsApplicationMixin(sheets.
       dropZone.addEventListener('dragleave', () => dropZone.classList.remove('drag-over'));
       dropZone.addEventListener('drop', async (ev) => {
         dropZone.classList.remove('drag-over');
-        const data = TextEditor.getDragEventData(ev);
+        const data = foundry.applications.ux.TextEditor.implementation.getDragEventData(ev);
         if (data.type !== "Item") return;
         const sourceItem = await fromUuid(data.uuid);
         if (sourceItem?.type !== "build") {

--- a/module/sheets/item-calling-sheet.mjs
+++ b/module/sheets/item-calling-sheet.mjs
@@ -151,7 +151,7 @@ export class TrespasserCallingSheet extends api.HandlebarsApplicationMixin(sheet
 
   async _onDropItem(event) {
     event.preventDefault();
-    const data = TextEditor.getDragEventData(event);
+    const data = foundry.applications.ux.TextEditor.implementation.getDragEventData(event);
     if (!data || data.type !== "Item") return;
 
     const listKey = event.currentTarget.dataset.list; // "talents" | "features" | "enhancements"

--- a/module/sheets/item-effect-sheet.mjs
+++ b/module/sheets/item-effect-sheet.mjs
@@ -37,8 +37,9 @@ export class TrespasserEffectSheet extends api.HandlebarsApplicationMixin(sheets
     
     if (!system.durationConditions) system.durationConditions = [];
 
-    // Map default status effects
-    const statusEffects = CONFIG.statusEffects
+    // Map default status effects.
+    // Object.values handles both the v13 array and v14 object formats
+    const statusEffects = Object.values(CONFIG.statusEffects)
       .map(effect => {
         const id = effect.id;
         const img = effect.img || effect.icon || effect.src || "";
@@ -116,7 +117,7 @@ export class TrespasserEffectSheet extends api.HandlebarsApplicationMixin(sheets
 
   async _onDropItem(event) {
     event.preventDefault();
-    const data = TextEditor.getDragEventData(event);
+    const data = foundry.applications.ux.TextEditor.implementation.getDragEventData(event);
     if (data.type !== "Item") return;
     
     const sourceItem = await fromUuid(data.uuid);

--- a/module/sheets/item-hireling-sheet.mjs
+++ b/module/sheets/item-hireling-sheet.mjs
@@ -135,7 +135,7 @@ export class TrespasserHirelingSheet extends api.HandlebarsApplicationMixin(shee
     const targetList = dropZone.dataset.type; // "consume" or "produce"
     if (!targetList) return;
 
-    const data = TextEditor.getDragEventData(event);
+    const data = foundry.applications.ux.TextEditor.implementation.getDragEventData(event);
     if (data.type !== "Item") return;
 
     const sourceItem = await fromUuid(data.uuid);

--- a/module/sheets/item-stronghold-sheet.mjs
+++ b/module/sheets/item-stronghold-sheet.mjs
@@ -110,7 +110,7 @@ export class TrespasserStrongholdSheet extends api.HandlebarsApplicationMixin(sh
       ownerZone.addEventListener('dragleave', () => ownerZone.classList.remove('drag-over'));
       ownerZone.addEventListener('drop', async (ev) => {
         ownerZone.classList.remove('drag-over');
-        const data = TextEditor.getDragEventData(ev);
+        const data = foundry.applications.ux.TextEditor.implementation.getDragEventData(ev);
         if (data.type !== "Actor") return;
         const sourceActor = await fromUuid(data.uuid);
         if (sourceActor?.type !== "character") {
@@ -131,7 +131,7 @@ export class TrespasserStrongholdSheet extends api.HandlebarsApplicationMixin(sh
       featuresZone.addEventListener('dragleave', () => featuresZone.classList.remove('drag-over'));
       featuresZone.addEventListener('drop', async (ev) => {
         featuresZone.classList.remove('drag-over');
-        const data = TextEditor.getDragEventData(ev);
+        const data = foundry.applications.ux.TextEditor.implementation.getDragEventData(ev);
         if (data.type !== "Item") return;
         const sourceItem = await fromUuid(data.uuid);
         if (sourceItem?.type !== "feature") {

--- a/templates/actor/creature-sheet.hbs
+++ b/templates/actor/creature-sheet.hbs
@@ -121,6 +121,31 @@
     <!-- Combat Effects -->
     {{> "systems/trespasser/templates/actor/parts/combat-effects.hbs"}}
 
+    <!-- Effects (Non-Combat) -->
+    <div class="effects-panel" style="margin-top: 15px; border-top: 2px solid var(--trp-border); padding-top: 10px;">
+      <h4>{{localize "TRESPASSER.Sheet.Character.NonCombatEffects"}}</h4>
+      <div class="effects-list">
+        {{#each activeEffects.nonCombat}}
+        {{#unless this.hiddenOnSheet}}
+        <div class="effect-row" data-item-id="{{this.id}}" style="display: flex; align-items: center; background: var(--trp-bg-overlay); margin-bottom: 5px; padding: 5px; border-radius: 4px;">
+          <div style="flex: 1;">
+            <b>{{this.name}}</b>{{#if (eq this.type "continuous")}} <span style="font-size: var(--fs-9); opacity: 0.7;">({{localize "TRESPASSER.App.System.Trigger.Continuous"}})</span>{{/if}}
+            <a class="effect-info" title="{{localize 'TRESPASSER.Sheet.Common.Info'}}"><i class="fas fa-info-circle"></i></a>
+            <a class="effect-edit" title="{{localize 'TRESPASSER.Sheet.Common.Edit'}}"><i class="fas fa-edit"></i></a>
+            {{#if this.sourceName}} <span style="font-size: var(--fs-11); font-weight: normal; color: var(--trp-text-dim);">({{this.sourceName}})</span>{{/if}}
+            (I: {{this.intensity}}) - {{this.target}}: {{this.modifier}}
+          </div>
+          <a class="item-control effect-remove" data-action="delete-effect" title="{{localize "TRESPASSER.Sheet.Common.Delete"}}">
+            <i class="fas fa-trash"></i>
+          </a>
+        </div>
+        {{/unless}}
+        {{else}}
+        <p class="notes">{{localize "TRESPASSER.Sheet.Character.NoNonCombatEffects"}}</p>
+        {{/each}}
+      </div>
+    </div>
+
     <!-- Deeds List -->
     <div class="deeds-section" style="margin-top: 15px;">
       <h3 class="section-title" style="margin-bottom: 0;">{{localize "TRESPASSER.Sheet.Combat.Deeds"}}</h3>

--- a/trespasser.mjs
+++ b/trespasser.mjs
@@ -791,6 +791,25 @@ Hooks.on("renderChatMessageHTML", (message, html, data) => {
     html.style.backgroundColor = "var(--trp-bg-dark)";
   }
 
+  // Resolve which tokens a chat-card action button should affect.
+  // Deed cards record the exact tokens that were hit in data-target-ids;
+  // cards without them fall back to the user's targets, then to controlled
+  // tokens. Never default to controlled-first: the attacker's own token is
+  // usually still selected after using a deed.
+  const resolveCardTargets = (btn) => {
+    const ids = (btn.dataset.targetIds ?? "").split(",").map(s => s.trim()).filter(Boolean);
+    if (ids.length) {
+      const tokens = ids.map(id => canvas.tokens.get(id)).filter(Boolean);
+      if (!tokens.length) ui.notifications.warn(game.i18n.localize("TRESPASSER.Notification.Combat.RecordedTargetsGone"));
+      return tokens;
+    }
+    const targeted = Array.from(game.user.targets);
+    if (targeted.length) return targeted;
+    if (canvas.tokens.controlled.length) return canvas.tokens.controlled;
+    ui.notifications.warn(game.i18n.localize("TRESPASSER.Notification.Combat.NoTargets"));
+    return [];
+  };
+
   html.querySelectorAll(".apply-effect-btn").forEach(btn => {
     btn.addEventListener("click", async (ev) => {
       ev.preventDefault();
@@ -806,11 +825,8 @@ Hooks.on("renderChatMessageHTML", (message, html, data) => {
 
       const baseIntensity = !isNaN(itemIntensity) ? itemIntensity : (sourceItem.system.intensity || 0);
 
-      const tokens = canvas.tokens.controlled;
-      if (tokens.length === 0) {
-        ui.notifications.warn(game.i18n.localize("TRESPASSER.Notification.Combat.NoTargets"));
-        return;
-      }
+      const tokens = resolveCardTargets(btn);
+      if (tokens.length === 0) return;
 
       for (const token of tokens) {
         const actor = token.actor;
@@ -871,13 +887,9 @@ Hooks.on("renderChatMessageHTML", (message, html, data) => {
       const rawDamage = parseInt(btn.dataset.damage);
       if (isNaN(rawDamage)) return;
 
-      // Prefer controlled tokens; fall back to targeted tokens
-      let tokens = canvas.tokens.controlled;
-      if (tokens.length === 0) tokens = Array.from(game.user.targets);
-      if (tokens.length === 0) {
-        ui.notifications.warn(game.i18n.localize("TRESPASSER.Notification.Combat.NoTargets"));
-        return;
-      }
+      // Card-recorded hit targets take precedence, then targeted, then controlled
+      const tokens = resolveCardTargets(btn);
+      if (tokens.length === 0) return;
 
       // Identify attacker from message speaker
       const messageId = btn.closest(".message")?.dataset.messageId;
@@ -924,12 +936,8 @@ Hooks.on("renderChatMessageHTML", (message, html, data) => {
       const healAmount = parseInt(btn.dataset.damage);
       if (isNaN(healAmount)) return;
 
-      let tokens = canvas.tokens.controlled;
-      if (tokens.length === 0) tokens = Array.from(game.user.targets);
-      if (tokens.length === 0) {
-        ui.notifications.warn(game.i18n.localize("TRESPASSER.Notification.Combat.NoTargets"));
-        return;
-      }
+      const tokens = resolveCardTargets(btn);
+      if (tokens.length === 0) return;
 
       for (const token of tokens) {
         const actor = token.actor;
@@ -1386,7 +1394,12 @@ Hooks.on("preCreateItem", (item, createData, options, userId) => {
     );
     if (existing) {
       const currentIntensity = existing.system.intensity || 0;
-      existing.update({ "system.intensity": currentIntensity + intensityToApply });
+      const newIntensity = currentIntensity + intensityToApply;
+      existing.update({ "system.intensity": newIntensity });
+      // Merging is silent data-wise; tell the user what happened to their drop
+      ui.notifications.info(game.i18n.format("TRESPASSER.Notification.Item.EffectMerged", {
+        effect: item.name, target: actor.name, intensity: newIntensity
+      }));
       return false; // Cancel creation of the new item
     }
 
@@ -1749,7 +1762,14 @@ Hooks.on("renderCombatTracker", async (app, html, data) => {
 Hooks.on("refreshToken", (token) => {
   // Remove old passive-state sprites
   const existing = token.children.filter(c => c._trespasserPassiveState);
-  existing.forEach(c => { token.removeChild(c); c.destroy(); });
+  existing.forEach(c => {
+    if (c._trespasserTooltip) {
+      game.tooltip.dismissLockedTooltip(c._trespasserTooltip);
+      c._trespasserTooltip = null;
+    }
+    token.removeChild(c);
+    c.destroy();
+  });
 
   const states = token.document?.actor?.system?.passiveStates;
   if (!states) return;
@@ -1773,15 +1793,26 @@ Hooks.on("refreshToken", (token) => {
     sprite.y = padding + index * (iconSize + padding);
     sprite.alpha = 0.9;
     sprite._trespasserPassiveState = true;
-    
-    // Tooltip on hover
+
+    // Tooltip on hover. TooltipManager#activate requires an HTMLElement, so
+    // for a canvas sprite we place a locked tooltip above the icon instead.
     sprite.eventMode = "static";
     sprite.on("pointerover", () => {
+      if (sprite._trespasserTooltip) return;
       const label = game.i18n.localize(cfg.label);
       const desc = game.i18n.localize(cfg.description);
-      game.tooltip.activate(sprite, { text: `${label}: ${desc}`, direction: "UP" });
+      const bounds = sprite.getBounds();
+      const board = document.getElementById("board")?.getBoundingClientRect() ?? { top: 0, left: 0 };
+      const tip = game.tooltip.createLockedTooltip({ top: "0px", left: "0px" }, `${label}: ${desc}`);
+      tip.style.left = `${Math.round(board.left + bounds.x + (bounds.width - tip.offsetWidth) / 2)}px`;
+      tip.style.top = `${Math.round(board.top + bounds.y - tip.offsetHeight - 4)}px`;
+      sprite._trespasserTooltip = tip;
     });
-    sprite.on("pointerout", () => game.tooltip.deactivate());
+    sprite.on("pointerout", () => {
+      if (!sprite._trespasserTooltip) return;
+      game.tooltip.dismissLockedTooltip(sprite._trespasserTooltip);
+      sprite._trespasserTooltip = null;
+    });
 
     token.addChild(sprite);
   });


### PR DESCRIPTION
Update to get the system running properly on Foundry v14, while also maintaining compatibility for v13. All change below were tested in both v14 and v13 worlds.

Everything that was broken in v14:
- Initiative system
- Tooltips for the status icons bloodied/encumbered
- Aura deeds
- Retreat feature
- chat card damage application
- Item dragging/dropping functionality

v13 compatibility approach:
Handled through new file 'module/helpers/compat.mjs' , deleting that module is all that is required once v13 support is eventually dropped.